### PR TITLE
Rust v1.41.1

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -277,7 +277,7 @@ RUN \
 
 ARG ARCH
 ARG TARGET="${ARCH}-bottlerocket-linux-gnu"
-ARG RUSTVER="1.41.0"
+ARG RUSTVER="1.41.1"
 
 USER builder
 WORKDIR /home/builder

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 ARCH ?= $(shell uname -m)
 
-VERSION := v0.9.0
+VERSION := v0.9.1
 TAG := bottlerocket/sdk-$(ARCH):$(VERSION)
 ARCHIVE := bottlerocket-sdk-$(ARCH)-$(VERSION).tar.gz
 

--- a/hashes/rust
+++ b/hashes/rust
@@ -1,6 +1,6 @@
-# https://static.rust-lang.org/dist/rustc-1.41.0-src.tar.xz
-SHA512 (rustc-1.41.0-src.tar.xz) = 0e30fe53b77860085bea0f1f60315eb835b00dd796c5d1b98ed44fe6fc27336dfb064908c86e1669a9cbe81c9ca1495e1c259a8a268bef23b23805a719cef0dd
-### See https://github.com/rust-lang/rust/blob/1.41.0/src/stage0.txt for what to use below. ###
+# https://static.rust-lang.org/dist/rustc-1.41.1-src.tar.xz
+SHA512 (rustc-1.41.1-src.tar.xz) = ef33565c9cf4e27ca279072bfed3301e0276c09407d49727640746ba78d289de285278d64b1cce8708461fd6c97c7ab2ea8d56e7a4c4a23b2e66e2d164c35fc9
+### See https://github.com/rust-lang/rust/blob/1.41.1/src/stage0.txt for what to use below. ###
 # https://static.rust-lang.org/dist/2019-12-19/rust-std-1.40.0-x86_64-unknown-linux-gnu.tar.xz
 SHA512 (rust-std-1.40.0-x86_64-unknown-linux-gnu.tar.xz) = caed73c08bf1af1e42fd425ab75957aa955a26fb61299af5d47279144d0d33f52c16c37f37bdb59ac7bb969c9a0b87bb0436e0b177a51942792efc8e89ef48ed
 # https://static.rust-lang.org/dist/2019-12-19/rustc-1.40.0-x86_64-unknown-linux-gnu.tar.xz


### PR DESCRIPTION
<!--
Tips:
- Please read the CONTRIBUTING document to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->

**Issue number:**

n/a

**Description of changes:**

Update Rust to v1.41.1. https://blog.rust-lang.org/2020/02/27/Rust-1.41.1.html

**Testing done:**

Built for both x86_64/aarch64. `cargo make world` in the main Bottlerocket built successfully.

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
