### PR TITLE
Go 1.14, Rust 1.42.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -277,7 +277,7 @@ RUN \
 
 ARG ARCH
 ARG TARGET="${ARCH}-bottlerocket-linux-gnu"
-ARG RUSTVER="1.41.1"
+ARG RUSTVER="1.42.0"
 
 USER builder
 WORKDIR /home/builder
@@ -309,7 +309,7 @@ FROM sdk-libc as sdk-go
 
 ARG ARCH
 ARG TARGET="${ARCH}-bottlerocket-linux-gnu"
-ARG GOVER="1.13.8"
+ARG GOVER="1.14"
 
 USER root
 RUN dnf -y install golang

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 ARCH ?= $(shell uname -m)
 
-VERSION := v0.9.1
+VERSION := v0.10.0
 TAG := bottlerocket/sdk-$(ARCH):$(VERSION)
 ARCHIVE := bottlerocket-sdk-$(ARCH)-$(VERSION).tar.gz
 

--- a/hashes/go
+++ b/hashes/go
@@ -1,2 +1,2 @@
-# https://dl.google.com/go/go1.13.8.src.tar.gz
-SHA512 (go1.13.8.src.tar.gz) = 5df45c4701631e7a70f4f25b07ed00dc9a56bdebeb5ead2d04e0e6b000e8a9f00d193247e626ef5b1e6b7fc54bf27fbc5e8fb21b23ab52ec397f2238c5dfa000
+# https://dl.google.com/go/go1.14.src.tar.gz
+SHA512 (go1.14.src.tar.gz) = b04f2a90b9693f2c7a0b5c7048f186318937f3dd3831162c4130d88e2b185a5047db15e284041c70f1f42da512f42e5e85c13256018982cf2739244a31874328

--- a/hashes/rust
+++ b/hashes/rust
@@ -1,9 +1,9 @@
-# https://static.rust-lang.org/dist/rustc-1.41.1-src.tar.xz
-SHA512 (rustc-1.41.1-src.tar.xz) = ef33565c9cf4e27ca279072bfed3301e0276c09407d49727640746ba78d289de285278d64b1cce8708461fd6c97c7ab2ea8d56e7a4c4a23b2e66e2d164c35fc9
-### See https://github.com/rust-lang/rust/blob/1.41.1/src/stage0.txt for what to use below. ###
-# https://static.rust-lang.org/dist/2019-12-19/rust-std-1.40.0-x86_64-unknown-linux-gnu.tar.xz
-SHA512 (rust-std-1.40.0-x86_64-unknown-linux-gnu.tar.xz) = caed73c08bf1af1e42fd425ab75957aa955a26fb61299af5d47279144d0d33f52c16c37f37bdb59ac7bb969c9a0b87bb0436e0b177a51942792efc8e89ef48ed
-# https://static.rust-lang.org/dist/2019-12-19/rustc-1.40.0-x86_64-unknown-linux-gnu.tar.xz
-SHA512 (rustc-1.40.0-x86_64-unknown-linux-gnu.tar.xz) = a461885cac4430dcd718f59b8528820a194c5b5e9e2289b3be9af1f19db49627207c0d83d506b89dcbdcd0ea0ff5cd29777337de791aab8d79e81547f6442f9c
-# https://static.rust-lang.org/dist/2019-12-19/cargo-0.41.0-x86_64-unknown-linux-gnu.tar.xz
-SHA512 (cargo-0.41.0-x86_64-unknown-linux-gnu.tar.xz) = ae18866f8e8c6d64a4776822762feee6c9cb427fe90aee1275abebb1d37d4ab970f0f9f0a8affe1bfb392899291f3be1b4ad8eafe5044a61504a5b0c2ea9aaf8
+# https://static.rust-lang.org/dist/rustc-1.42.0-src.tar.xz
+SHA512 (rustc-1.42.0-src.tar.xz) = 589bfdc92deedd33b8ea0df7f7c64c2a9a085fbea64936eff92f81e812309c060ed7a7adc96f6010d7adf62a68434a230da0f6c5b3540df4e0a5c6de05a31b16
+### See https://github.com/rust-lang/rust/blob/1.42.0/src/stage0.txt for what to use below. ###
+# https://static.rust-lang.org/dist/2020-02-27/rust-std-1.41.1-x86_64-unknown-linux-gnu.tar.xz
+SHA512 (rust-std-1.41.1-x86_64-unknown-linux-gnu.tar.xz) = 705ac8b533b7aba15ad7582e6fcec19f7bc4ac76dafec6d64686c61cd5395344f7bd11680796cb89b05f78a159d0f18133c877d7c3885df22c1964dec31064a6
+# https://static.rust-lang.org/dist/2020-02-27/rustc-1.41.1-x86_64-unknown-linux-gnu.tar.xz
+SHA512 (rustc-1.41.1-x86_64-unknown-linux-gnu.tar.xz) = 6b1fadde5bf1c2c7d97071bb01b4d9112ba0ce630c0fd240d99322dc8b70a604e3e3fd11040a1abeb74b253375aabbf97e5400b7c0c9a074cb5f067d55d61894
+# https://static.rust-lang.org/dist/2020-02-27/cargo-0.42.0-x86_64-unknown-linux-gnu.tar.xz
+SHA512 (cargo-0.42.0-x86_64-unknown-linux-gnu.tar.xz) = de21b025fcd3f512bdd089cc1254798ba50cfb3709a2ff51780fbd68457931784b71429d038eab06c963715a9a627ae8e0b6c8d0b4bbe1420a5b68b343e410c2


### PR DESCRIPTION
<!--
Tips:
- Please read the CONTRIBUTING document to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->

**Issue number:**

Fixes #17, #18

**Description of changes:**

Update Go to 1.14.
Update Rust to 1.42.0.
Update the SDK version to 0.10.0.

**Testing done:**

```plain
[ec2-user@ip-172-31-34-85 ~]$ docker run --rm -it bottlerocket/sdk-x86_64:v0.10.0
[builder@fc0cd1d11bbe /]$ go version
go version go1.14 linux/amd64
[builder@fc0cd1d11bbe /]$ rustc --version
rustc 1.42.0
```

Built an image, a pod runs fine, admin container comes up and SSH works.

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
