### PR TITLE
update SDK to v0.13.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -277,7 +277,7 @@ RUN \
 
 ARG ARCH
 ARG VENDOR="bottlerocket"
-ARG RUSTVER="1.45.2"
+ARG RUSTVER="1.46.0"
 
 USER builder
 WORKDIR /home/builder

--- a/Dockerfile
+++ b/Dockerfile
@@ -127,7 +127,7 @@ COPY --from=toolchain-musl \
 FROM sdk as sdk-gnu
 USER builder
 
-ARG GLIBCVER="2.31"
+ARG GLIBCVER="2.32"
 
 WORKDIR /home/builder
 COPY ./hashes/glibc ./hashes

--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,9 @@
 ARCH ?= $(shell uname -m)
+HOST_ARCH ?= $(shell uname -m)
 
-VERSION := v0.12.0
-TAG := bottlerocket/sdk-$(ARCH):$(VERSION)
-ARCHIVE := bottlerocket-sdk-$(ARCH)-$(VERSION).tar.gz
+VERSION := v0.13.0
+TAG := bottlerocket/sdk-$(ARCH):$(VERSION)-$(HOST_ARCH)
+ARCHIVE := bottlerocket-sdk-$(ARCH)-$(VERSION).$(HOST_ARCH).tar.gz
 
 $(ARCHIVE) :
 	@DOCKER_BUILDKIT=1 docker build . -t $(TAG) --squash --build-arg ARCH=$(ARCH)

--- a/README.md
+++ b/README.md
@@ -21,4 +21,4 @@ make ARCH=x86_64
 make ARCH=aarch64
 ```
 
-Currently it assumes an x86_64 build host for both cases.
+It supports either an x86_64 or an aarch64 build host for both cases.

--- a/configs/rust/config-aarch64.toml
+++ b/configs/rust/config-aarch64.toml
@@ -1,13 +1,7 @@
 [build]
-build = "x86_64-unknown-linux-gnu"
-
-host = [
-  "x86_64-unknown-linux-gnu",
-]
-
 target = [
-  "aarch64-unknown-linux-gnu",
-  "aarch64-unknown-linux-musl",
+  "aarch64-bottlerocket-linux-gnu",
+  "aarch64-bottlerocket-linux-musl",
 ]
 
 docs = false
@@ -28,7 +22,7 @@ rpath = false
 prefix = "/usr/libexec/rust"
 sysconfdir = "/usr/libexec/rust/etc"
 
-[target.aarch64-unknown-linux-gnu]
+[target.aarch64-bottlerocket-linux-gnu]
 cc = "aarch64-bottlerocket-linux-gnu-gcc"
 cxx = "aarch64-bottlerocket-linux-gnu-g++"
 ar = "/usr/bin/aarch64-bottlerocket-linux-gnu-ar"
@@ -36,7 +30,7 @@ ranlib = "/usr/bin/aarch64-bottlerocket-linux-gnu-ranlib"
 linker = "aarch64-bottlerocket-linux-gnu-gcc"
 crt-static = false
 
-[target.aarch64-unknown-linux-musl]
+[target.aarch64-bottlerocket-linux-musl]
 cc = "aarch64-bottlerocket-linux-musl-gcc"
 cxx = "aarch64-bottlerocket-linux-musl-g++"
 ar = "/usr/bin/aarch64-bottlerocket-linux-musl-ar"

--- a/configs/rust/config-x86_64.toml
+++ b/configs/rust/config-x86_64.toml
@@ -1,12 +1,7 @@
 [build]
-build = "x86_64-unknown-linux-gnu"
-
-host = [
-  "x86_64-unknown-linux-gnu",
-]
-
 target = [
-  "x86_64-unknown-linux-musl",
+  "x86_64-bottlerocket-linux-gnu",
+  "x86_64-bottlerocket-linux-musl",
 ]
 
 docs = false
@@ -27,7 +22,15 @@ rpath = false
 prefix = "/usr/libexec/rust"
 sysconfdir = "/usr/libexec/rust/etc"
 
-[target.x86_64-unknown-linux-musl]
+[target.x86_64-bottlerocket-linux-gnu]
+cc = "x86_64-bottlerocket-linux-gnu-gcc"
+cxx = "x86_64-bottlerocket-linux-gnu-g++"
+ar = "/usr/bin/x86_64-bottlerocket-linux-gnu-ar"
+ranlib = "/usr/bin/x86_64-bottlerocket-linux-gnu-ranlib"
+linker = "x86_64-bottlerocket-linux-gnu-gcc"
+crt-static = false
+
+[target.x86_64-bottlerocket-linux-musl]
 cc = "x86_64-bottlerocket-linux-musl-gcc"
 cxx = "x86_64-bottlerocket-linux-musl-g++"
 ar = "/usr/bin/x86_64-bottlerocket-linux-musl-ar"

--- a/hashes/glibc
+++ b/hashes/glibc
@@ -1,2 +1,2 @@
-# https://mirrors.kernel.org/gnu/glibc/glibc-2.31.tar.xz
-SHA512 (glibc-2.31.tar.xz) = 735e4c0ef10418b6ea945ad3906585e5bbd8b282d76f2131309dce4cec6b15066a5e4a3731773ce428a819b542579c9957867bb0abf05ed2030983fca4412306
+# https://mirrors.kernel.org/gnu/glibc/glibc-2.32.tar.xz
+SHA512 (glibc-2.32.tar.xz) = 8460c155b7003e04f18dabece4ed9ad77445fa2288a7dc08e80a8fc4c418828af29e0649951bd71a54ea2ad2d4da7570aafd9bdfe4a37e9951b772b442afe50b

--- a/hashes/rust
+++ b/hashes/rust
@@ -1,9 +1,15 @@
-# https://static.rust-lang.org/dist/rustc-1.45.2-src.tar.xz
-SHA512 (rustc-1.45.2-src.tar.xz) = cc6250c0bc844e77ca6dd7ae013e434ed3009b001914114866ed31f28edf3960221454d131e298b15050e3b8153fb8298d509559c2f7307c64611aa8e36b4d25
-### See https://github.com/rust-lang/rust/blob/1.45.2/src/stage0.txt for what to use below. ###
-# https://static.rust-lang.org/dist/2020-06-04/rust-std-1.44.0-x86_64-unknown-linux-gnu.tar.xz
-SHA512 (rust-std-1.44.0-x86_64-unknown-linux-gnu.tar.xz) = 40fb579b86a86717d79c92586a949e2278ff4a948def6499a75cb3d54cb5752d4602d5d82c7d1ca6a7e50b84fd218cb0e016f5bcbd971b8006d01b98b05850de
-# https://static.rust-lang.org/dist/2020-06-04/rustc-1.44.0-x86_64-unknown-linux-gnu.tar.xz
-SHA512 (rustc-1.44.0-x86_64-unknown-linux-gnu.tar.xz) = fa9ed7bd3d380a7b15cf1f000adb208f75ac6148d40926aa52f6865dd8ca6dcb086fac2e982dc8179cb0faf3d133649365e488bf86bf458b2a6711fb470d34b5
-# https://static.rust-lang.org/dist/2020-06-04/cargo-0.45.0-x86_64-unknown-linux-gnu.tar.xz
-SHA512 (cargo-0.45.0-x86_64-unknown-linux-gnu.tar.xz) = 9e55f503cebd3ff338c6ac05480ee249275d0c59efc6d189a78225cc3e2bfae323d6a2411f1631517bdc5601ecb3cd761333d1b0383e9b51fbca29be108594b9
+# https://static.rust-lang.org/dist/rustc-1.46.0-src.tar.xz
+SHA512 (rustc-1.46.0-src.tar.xz) = 099857f1d295043587a4e2a65ef3e6a90e12c8b6958e98535a1656c113c553f9a9b621aba8a19cf21bd8d2c79d27cbfa4b8e6fabbcb3cbfee23b545be7b450b4
+### See https://github.com/rust-lang/rust/blob/1.46.0/src/stage0.txt for what to use below. ###
+# https://static.rust-lang.org/dist/2020-08-03/rust-std-1.45.2-aarch64-unknown-linux-gnu.tar.xz
+SHA512 (rust-std-1.45.2-aarch64-unknown-linux-gnu.tar.xz) = c5104fac8caebfec9130d27982e0c2215ebe3967adeb8d011891837ebc049e812943059b31d258522426890d3c7ce1f5dd1ef4a540c6aa238bc48c9633444d0e
+# https://static.rust-lang.org/dist/2020-08-03/rust-std-1.45.2-x86_64-unknown-linux-gnu.tar.xz
+SHA512 (rust-std-1.45.2-x86_64-unknown-linux-gnu.tar.xz) = 48e0efe0e667cb9986890e10b1e9d7e3862d124773697a9946e9f7c5579611f102e692d5e586f604a05a8f7a5cb4df59e882cd384e9763f932e0d3ac0711bd12
+# https://static.rust-lang.org/dist/2020-08-03/rustc-1.45.2-aarch64-unknown-linux-gnu.tar.xz
+SHA512 (rustc-1.45.2-aarch64-unknown-linux-gnu.tar.xz) = af472e6707e29fec607d41eb03cd529502620c8114204319ae1d09f0955789c94218e1f42b6acef873b25858e77bf6aedd8c96ebab0de3980ab58fb9319619c6
+# https://static.rust-lang.org/dist/2020-08-03/rustc-1.45.2-x86_64-unknown-linux-gnu.tar.xz
+SHA512 (rustc-1.45.2-x86_64-unknown-linux-gnu.tar.xz) = 8bfa62ae3cccdabaaebe985fadbc8ed4f98cce81670cbc8c8f64ea4389a6794c003de126401ecabbffd06fcca1cf1177a8bcfa5986ed85d1ec6327c9b7ede11e
+# https://static.rust-lang.org/dist/2020-08-03/cargo-0.46.1-aarch64-unknown-linux-gnu.tar.xz
+SHA512 (cargo-0.46.1-aarch64-unknown-linux-gnu.tar.xz) = 6759299e2386602f092f4cc77292b3ad8770547a06861dc131e4cd93973b387e215f920872206537dd64a0ea42104d8e2cbfb46b64bb6a3ca158f9fb9364826f
+# https://static.rust-lang.org/dist/2020-08-03/cargo-0.46.1-x86_64-unknown-linux-gnu.tar.xz
+SHA512 (cargo-0.46.1-x86_64-unknown-linux-gnu.tar.xz) = 8e0e69d98a2202b57ff29b4076fca2e0b48a4230142ecb79424611d5b76080a48a77c16ccda4ca8e72f31cee2c625638428c13aff3e4bbb8caf3a2c26bca43ae


### PR DESCRIPTION
**Issue number:**
Closes #28 
Closes #31
Closes #32 


**Description of changes:**
The major change is the additional of new, vendor-specific Rust targets. These are copied from the "unknown" vendor targets we used previously. The goal is to eliminate the host/target confusion for Rust that existed when building for `x86_64-unknown-linux-gnu` on x86_64, or for `aarch64-unknown-linux-gnu` on aarch64.

This caused a few subtle issues, such as linking host programs using our target GCC toolchain and C library, which prevented us from updating glibc either here or in the OS. Now we're free to take the glibc update.

The update to Rust 1.46.0 also includes aarch64 versions of the stage-0 artifacts, so that we can build the SDK on aarch64 hosts. Enabling this is another happy side effect of the new vendor targets.


**Testing done:**
Built the four supported SDK combinations:
* x86_64 host, x86_64 target
* x86_64 host, aarch64 target
* aarch64 host, x86_64 target
* aarch64 host, aarch64 target

Verified that an x86_64 host could build the OS for both targets, and likewise that an aarch64 host could build the OS for both targets. Verified that the resulting artifacts worked as expected when registered as AMIs.


**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
