### PR TITLE
update toolchain and add archive target

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,7 +19,21 @@ COPY ./sdk-fetch /usr/local/bin
 
 # =^..^=   =^..^=   =^..^=   =^..^=   =^..^=   =^..^=   =^..^=   =^..^=   =^..^=
 
-FROM base as toolchain
+# We expect our C cross-compiler to be used on other distros for building kernel
+# modules, so we build it with an older glibc for compatibility.
+FROM ubuntu:16.04 as compat
+RUN \
+  apt-get update && \
+  apt-get -y dist-upgrade && \
+  apt-get -y install \
+    autoconf automake bc build-essential cpio curl file git \
+    libexpat1-dev libtool libz-dev pkgconf python3 unzip wget && \
+  useradd -m -u 1000 builder
+COPY ./sdk-fetch /usr/local/bin
+
+# =^..^=   =^..^=   =^..^=   =^..^=   =^..^=   =^..^=   =^..^=   =^..^=   =^..^=
+
+FROM compat as toolchain
 USER builder
 
 # Configure Git for any subsequent use.
@@ -57,6 +71,7 @@ RUN \
   find output/${ARCH}-gnu/build/linux-headers-${KVER}/usr/include -name '.*' -delete
 
 WORKDIR /home/builder/buildroot/output/${ARCH}-gnu/build
+SHELL ["/bin/bash", "-c"]
 RUN \
   install -p -m 0644 -Dt licenses/binutils host-binutils-*/COPYING{,3}{,.LIB} && \
   install -p -m 0644 -Dt licenses/bison host-bison-*/COPYING && \
@@ -67,8 +82,7 @@ RUN \
   install -p -m 0644 -Dt licenses/linux linux-headers-*/{COPYING,LICENSES/preferred/GPL-2.0,LICENSES/exceptions/Linux-syscall-note} && \
   install -p -m 0644 -Dt licenses/m4 host-m4-*/COPYING && \
   install -p -m 0644 -Dt licenses/mpc host-mpc-*/COPYING.LESSER && \
-  install -p -m 0644 -Dt licenses/mpfr host-mpfr-*/COPYING{,.LESSER} && \
-  install -p -m 0644 -Dt licenses/tar host-tar-*/COPYING
+  install -p -m 0644 -Dt licenses/mpfr host-mpfr-*/COPYING{,.LESSER}
 
 # =^..^=   =^..^=   =^..^=   =^..^=   =^..^=   =^..^=   =^..^=   =^..^=   =^..^=
 
@@ -81,6 +95,7 @@ RUN \
   find output/${ARCH}-musl/build/linux-headers-${KVER}/usr/include -name '.*' -delete
 
 WORKDIR /home/builder/buildroot/output/${ARCH}-musl/build
+SHELL ["/bin/bash", "-c"]
 RUN \
   install -p -m 0644 -Dt licenses/binutils host-binutils-*/COPYING{,3}{,.LIB} && \
   install -p -m 0644 -Dt licenses/gcc host-gcc-final-*/{COPYING,COPYING.LIB,COPYING.RUNTIME,COPYING3,COPYING3.LIB} && \
@@ -89,8 +104,7 @@ RUN \
   install -p -m 0644 -Dt licenses/linux linux-headers-*/{COPYING,LICENSES/preferred/GPL-2.0,LICENSES/exceptions/Linux-syscall-note} && \
   install -p -m 0644 -Dt licenses/m4 host-m4-*/COPYING && \
   install -p -m 0644 -Dt licenses/mpc host-mpc-*/COPYING.LESSER && \
-  install -p -m 0644 -Dt licenses/mpfr host-mpfr-*/COPYING{,.LESSER} && \
-  install -p -m 0644 -Dt licenses/tar host-tar-*/COPYING
+  install -p -m 0644 -Dt licenses/mpfr host-mpfr-*/COPYING{,.LESSER}
 
 # For kernel module development, we only need one toolchain, and it doesn't
 # matter which one we pick since the kernel doesn't use the C library. Record

--- a/Dockerfile
+++ b/Dockerfile
@@ -300,7 +300,7 @@ RUN \
 
 ARG ARCH
 ARG VENDOR="bottlerocket"
-ARG RUSTVER="1.46.0"
+ARG RUSTVER="1.47.0"
 
 USER builder
 WORKDIR /home/builder

--- a/Dockerfile
+++ b/Dockerfile
@@ -372,7 +372,7 @@ FROM sdk-libc as sdk-go
 
 ARG ARCH
 ARG TARGET="${ARCH}-bottlerocket-linux-gnu"
-ARG GOVER="1.14.7"
+ARG GOVER="1.15.4"
 
 USER root
 RUN dnf -y install golang

--- a/Makefile
+++ b/Makefile
@@ -2,17 +2,36 @@ ARCH ?= $(shell uname -m)
 HOST_ARCH ?= $(shell uname -m)
 
 VERSION := v0.13.0
-TAG := bottlerocket/sdk-$(ARCH):$(VERSION)-$(HOST_ARCH)
-ARCHIVE := bottlerocket-sdk-$(ARCH)-$(VERSION).$(HOST_ARCH).tar.gz
 
-$(ARCHIVE) :
-	@DOCKER_BUILDKIT=1 docker build . -t $(TAG) --squash --build-arg ARCH=$(ARCH)
-	@docker image save $(TAG) | gzip --fast > $(@)
+SDK_TAG := bottlerocket/sdk-$(ARCH):$(VERSION)-$(HOST_ARCH)
+SDK_ARCHIVE := bottlerocket-sdk-$(ARCH)-$(VERSION).$(HOST_ARCH).tar.gz
 
-.PHONY: upload clean
+TOOLCHAIN_TAG := bottlerocket/toolchain-$(ARCH):$(VERSION)-$(HOST_ARCH)
+TOOLCHAIN_ARCHIVE := bottlerocket-toolchain-$(ARCH)-$(VERSION).$(HOST_ARCH).tar.xz
 
-upload : $(ARCHIVE)
-	@aws s3 cp $(ARCHIVE) s3://thar-upstream-lookaside-cache/$(TAG).tar.gz
+all: $(SDK_ARCHIVE) $(TOOLCHAIN_ARCHIVE)
+
+$(SDK_ARCHIVE) :
+	@DOCKER_BUILDKIT=1 docker build . \
+		--tag $(SDK_TAG) \
+		--target sdk-final \
+		--squash \
+		--build-arg ARCH=$(ARCH)
+	@docker image save $(SDK_TAG) | gzip --fast > $(@)
+
+$(TOOLCHAIN_ARCHIVE) :
+	@DOCKER_BUILDKIT=1 docker build . \
+		--tag $(TOOLCHAIN_TAG) \
+		--target toolchain-final \
+		--squash \
+		--build-arg ARCH=$(ARCH)
+	@docker run --rm --entrypoint cat $(TOOLCHAIN_TAG) /tmp/toolchain.tar.xz > $(@)
+
+upload : $(SDK_ARCHIVE) $(TOOLCHAIN_ARCHIVE)
+	@aws s3 cp $(SDK_ARCHIVE) s3://thar-upstream-lookaside-cache/$(SDK_TAG).tar.gz
+	@aws s3 cp $(TOOLCHAIN_ARCHIVE) s3://thar-upstream-lookaside-cache/$(TOOLCHAIN_TAG).tar.xz
 
 clean:
-	@rm -f *.tar.gz
+	@rm -f *.tar.gz *.tar.xz
+
+.PHONY: all upload clean

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 ARCH ?= $(shell uname -m)
 HOST_ARCH ?= $(shell uname -m)
 
-VERSION := v0.13.0
+VERSION := v0.14.0
 
 SDK_TAG := bottlerocket/sdk-$(ARCH):$(VERSION)-$(HOST_ARCH)
 SDK_ARCHIVE := bottlerocket-sdk-$(ARCH)-$(VERSION).$(HOST_ARCH).tar.gz

--- a/hashes/buildroot
+++ b/hashes/buildroot
@@ -26,5 +26,3 @@ SHA512 (mpc-1.1.0.tar.gz) = 72d657958b07c7812dc9c7cbae093118ce0e454c68a585bfb0e2
 SHA512 (mpfr-4.0.2.tar.xz) = d583555d08863bf36c89b289ae26bae353d9a31f08ee3894520992d2c26e5683c4c9c193d7ad139632f71c0a476d85ea76182702a98bf08dde7b6f65a54f8b88
 # http://cvsweb.netbsd.org/bsdweb.cgi/src/sys/sys/queue.h?rev=1.70
 SHA512 (queue.h) = 2f0d5e6e4dc3350285cf17009265dddcbe12431c111868eea39bc8cb038ab7c1f2acacbb21735c4e9d4a1fd106a8fc0f8611ea33987d4faba37dde5ce6da0750
-# https://mirrors.kernel.org/gnu/tar/tar-1.29.cpio.gz
-SHA512 (tar-1.29.cpio.gz) = f004683b68db8a35bb517b92286063acedd01cf88fec2d61b7649fdcb8db855559c98de688b207c146ce01ea5778185f447da924c4c5061db739a8a7528718a5

--- a/hashes/go
+++ b/hashes/go
@@ -1,2 +1,2 @@
-# https://dl.google.com/go/go1.14.7.src.tar.gz
-SHA512 (go1.14.7.src.tar.gz) = 3f1133c66d7795ceb6c5793db90616613244d7561abaef6b059602992c0b7a53b6b6ebbcf69add4769a58542e9dc55871bcfe3d64d4cd9f3569bd435ade86dee
+# https://golang.org/dl/go1.15.4.src.tar.gz
+SHA512 (go1.15.4.src.tar.gz) = 84fc687806d7904be0afcdfb4f45a74b4b45820c5c79b21b0c82cd51d07f3f8ae37e7f80730a411b96bdcf7f635b473ab0233c1bce977d2cf307d9a63aeb3df5

--- a/hashes/rust
+++ b/hashes/rust
@@ -1,15 +1,15 @@
-# https://static.rust-lang.org/dist/rustc-1.46.0-src.tar.xz
-SHA512 (rustc-1.46.0-src.tar.xz) = 099857f1d295043587a4e2a65ef3e6a90e12c8b6958e98535a1656c113c553f9a9b621aba8a19cf21bd8d2c79d27cbfa4b8e6fabbcb3cbfee23b545be7b450b4
-### See https://github.com/rust-lang/rust/blob/1.46.0/src/stage0.txt for what to use below. ###
-# https://static.rust-lang.org/dist/2020-08-03/rust-std-1.45.2-aarch64-unknown-linux-gnu.tar.xz
-SHA512 (rust-std-1.45.2-aarch64-unknown-linux-gnu.tar.xz) = c5104fac8caebfec9130d27982e0c2215ebe3967adeb8d011891837ebc049e812943059b31d258522426890d3c7ce1f5dd1ef4a540c6aa238bc48c9633444d0e
-# https://static.rust-lang.org/dist/2020-08-03/rust-std-1.45.2-x86_64-unknown-linux-gnu.tar.xz
-SHA512 (rust-std-1.45.2-x86_64-unknown-linux-gnu.tar.xz) = 48e0efe0e667cb9986890e10b1e9d7e3862d124773697a9946e9f7c5579611f102e692d5e586f604a05a8f7a5cb4df59e882cd384e9763f932e0d3ac0711bd12
-# https://static.rust-lang.org/dist/2020-08-03/rustc-1.45.2-aarch64-unknown-linux-gnu.tar.xz
-SHA512 (rustc-1.45.2-aarch64-unknown-linux-gnu.tar.xz) = af472e6707e29fec607d41eb03cd529502620c8114204319ae1d09f0955789c94218e1f42b6acef873b25858e77bf6aedd8c96ebab0de3980ab58fb9319619c6
-# https://static.rust-lang.org/dist/2020-08-03/rustc-1.45.2-x86_64-unknown-linux-gnu.tar.xz
-SHA512 (rustc-1.45.2-x86_64-unknown-linux-gnu.tar.xz) = 8bfa62ae3cccdabaaebe985fadbc8ed4f98cce81670cbc8c8f64ea4389a6794c003de126401ecabbffd06fcca1cf1177a8bcfa5986ed85d1ec6327c9b7ede11e
-# https://static.rust-lang.org/dist/2020-08-03/cargo-0.46.1-aarch64-unknown-linux-gnu.tar.xz
-SHA512 (cargo-0.46.1-aarch64-unknown-linux-gnu.tar.xz) = 6759299e2386602f092f4cc77292b3ad8770547a06861dc131e4cd93973b387e215f920872206537dd64a0ea42104d8e2cbfb46b64bb6a3ca158f9fb9364826f
-# https://static.rust-lang.org/dist/2020-08-03/cargo-0.46.1-x86_64-unknown-linux-gnu.tar.xz
-SHA512 (cargo-0.46.1-x86_64-unknown-linux-gnu.tar.xz) = 8e0e69d98a2202b57ff29b4076fca2e0b48a4230142ecb79424611d5b76080a48a77c16ccda4ca8e72f31cee2c625638428c13aff3e4bbb8caf3a2c26bca43ae
+# https://static.rust-lang.org/dist/rustc-1.47.0-src.tar.xz
+SHA512 (rustc-1.47.0-src.tar.xz) = 6ba83c0158f8130ddeae7e070417a2121d8a548c8fe97e28bce116d84048636c75aaee78e0c92cd43a50f5679a1223fc226cc8c5ba9bbd1465e84c5c6034d5c9
+### See https://github.com/rust-lang/rust/blob/1.47.0/src/stage0.txt for what to use below. ###
+# https://static.rust-lang.org/dist/2020-08-27/rust-std-1.46.0-x86_64-unknown-linux-gnu.tar.xz
+SHA512 (rust-std-1.46.0-x86_64-unknown-linux-gnu.tar.xz) = dd8d05d4c89a60057b0aaa9bfe12cfaf77c7b429e1f51f3b1dcc6dba17221bcaa5f1fde1681ea30b018248c0c601efbe981b2a214ebb1a3a75de2c1353fbe19f
+# https://static.rust-lang.org/dist/2020-08-27/rustc-1.46.0-x86_64-unknown-linux-gnu.tar.xz
+SHA512 (rustc-1.46.0-x86_64-unknown-linux-gnu.tar.xz) = 0ad14639eaa57b75dbe0b56cbdd12450bc484fdc02bf05ec756a3a796eb520e13c89d5f3006c5f49a86581c6493b7b34e8d7aa2ec327d1a94d350cb2f763c65b
+# https://static.rust-lang.org/dist/2020-08-27/cargo-0.47.0-x86_64-unknown-linux-gnu.tar.xz
+SHA512 (cargo-0.47.0-x86_64-unknown-linux-gnu.tar.xz) = 4a87588fe0f37d2ddff30dcfbbf909ea2570a78c6ca562aecfa4cc08112e7222418a5dd67f14665730b3813b0de283cd9d86fb1b3d835b5e68277a45c76c85eb
+# https://static.rust-lang.org/dist/2020-08-27/rust-std-1.46.0-aarch64-unknown-linux-gnu.tar.xz
+SHA512 (rust-std-1.46.0-aarch64-unknown-linux-gnu.tar.xz) = 16f7cbfe9023a60b87fef6d29cc1fc1144e0c79eea990a582d6d055331a2d927426fe805c491c200d11cbb3dec17567b6b39a3371f7b62ffd2eec571de0e81de
+# https://static.rust-lang.org/dist/2020-08-27/rustc-1.46.0-aarch64-unknown-linux-gnu.tar.xz
+SHA512 (rustc-1.46.0-aarch64-unknown-linux-gnu.tar.xz) = 472abc1a91bae03608b6fbb17ee2d210bc43e2081ac5784351316838fe5ac9b3ab36b88bd84ef63618c2374e38ba6cb6799e337153f0542f7b6c694551f1149e
+# https://static.rust-lang.org/dist/2020-08-27/cargo-0.47.0-aarch64-unknown-linux-gnu.tar.xz
+SHA512 (cargo-0.47.0-aarch64-unknown-linux-gnu.tar.xz) = 3b08b403d6ce77a42b930fb9510506447b787d765e58287f8008554a5b36b76fbb03fef4ef517c4dbfd79e4e7b9c638b38fc005da0bd7fafc72eaf26df6e0c76


### PR DESCRIPTION
**Issue number:**
Partly addresses #7, fixes #34 and fixes #36.


**Description of changes:**
Create a toolchain archive target that we can use to extract gcc and binutils from the SDK, so that it can be used in contexts where running a container is difficult.

To make the toolchain work on distros other than a recent Fedora, build the toolchain with an older Ubuntu.

Update Go to 1.15.4, Rust to 1.47.


**Testing done:**
Verified that I can use the SDK to build Bottlerocket on both architectures (x86_64, aarch64) for both architectures. A small fix is needed for Go programs to add `linkmode=external` to ldflags, since the default linker for `buildmode=pie` changed in Go 1.15.

Confirmed that the toolchain archive has the expected contents:
```
❯ tar tf bottlerocket-toolchain-aarch64-v0.14.0.aarch64.tar.xz
...
toolchain/usr/bin/aarch64-bottlerocket-linux-musl-gcc
...
toolchain/licenses/gcc/COPYING3
toolchain/licenses/gcc/COPYING.RUNTIME
toolchain/licenses/gcc/COPYING3.LIB
toolchain/licenses/gcc/COPYING.LIB
toolchain/licenses/gcc/COPYING
...
```

Verified that I can use the toolchain archive to build out-of-tree kernel modules:
* x86_64 - Falco, Wireguard, ZFS
* aarch64 - Wireguard, ZFS

Tested the module build using Amazon Linux 2 and Fedora 32 base layers on both architectures.

Confirmed that the module could be loaded on instances for both architectures.


**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
