### PR TITLE
add qemu-img to the SDK

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,7 @@ RUN \
     dwarves elfutils-devel libcap-devel openssl-devel \
     createrepo_c e2fsprogs gdisk grub2-tools.$(uname -m) \
     kpartx lz4 veritysetup dosfstools mtools squashfs-tools \
-    policycoreutils secilc && \
+    policycoreutils secilc qemu-img && \
   dnf clean all && \
   useradd builder
 COPY ./sdk-fetch /usr/local/bin


### PR DESCRIPTION
**Issue number:**
N/A


**Description of changes:**
This will be used to convert raw disk images into other formats.


**Testing done:**
`qemu-img` works.

```
❯ docker run -it --rm bottlerocket/sdk-x86_64:v0.15.0-aarch64
[builder@c1dc510a41f7 /]$ qemu-img create -f qcow2 /tmp/disk.img 10G
Formatting '/tmp/disk.img', fmt=qcow2 size=10737418240 cluster_size=65536 lazy_refcounts=off refcount_bits=16
```


**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
