### PR TITLE
add glib2-devel and rpcgen

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,8 @@ RUN \
     dwarves elfutils-devel libcap-devel openssl-devel \
     createrepo_c e2fsprogs gdisk grub2-tools.$(uname -m) \
     kpartx lz4 veritysetup dosfstools mtools squashfs-tools \
-    perl-FindBin perl-open policycoreutils secilc qemu-img && \
+    perl-FindBin perl-open policycoreutils secilc qemu-img \
+    glib2-devel rpcgen && \
   dnf clean all && \
   useradd builder
 COPY ./sdk-fetch /usr/local/bin

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 ARCH ?= $(shell uname -m)
 HOST_ARCH ?= $(shell uname -m)
 
-VERSION := v0.20.0
+VERSION := v0.21.0
 
 SDK_TAG := bottlerocket/sdk-$(ARCH):$(VERSION)-$(HOST_ARCH)
 TOOLCHAIN_TAG := bottlerocket/toolchain-$(ARCH):$(VERSION)-$(HOST_ARCH)


### PR DESCRIPTION
**Issue number:**
https://github.com/bottlerocket-os/bottlerocket/issues/1510

**Description of changes:**
Add `glib2-devel` (for `glib-genmarshal`) and `rpcgen`, which provide host tools needed to build `open-vm-tools`.


**Testing done:**
Built `open-vm-tools`.


**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
