### PR TITLE
add govc

### DIFF
--- a/hashes/govmomi
+++ b/hashes/govmomi
@@ -1,0 +1,2 @@
+# https://github.com/vmware/govmomi/archive/v0.26.0.tar.gz#/govmomi-0.26.0.tar.gz
+SHA512 (govmomi-0.26.0.tar.gz) = 51e1e41fd230781b841ed238ce87d81e6b6902c67f1aae91c1245bcb69a696d13baaadae4f67e59bf58b018c6fc1e808168eb55eb4b351f82ace8a16633daa5c


### PR DESCRIPTION
**Issue number:**

https://github.com/bottlerocket-os/bottlerocket/issues/1605

**Description of changes:**

Add `govmomi/govc`, which provides the host tool needed to support uploading OVAs.

**Testing done:**

Built SDK with `govc` on both architectures. Also tested cross-compilation.

```
$ /usr/libexec/tools/govc version -l
Build Version: 0.26.0
Build Commit: 34586b6
Build Date: 2021-06-08T18:43:48Z
```

Verified license artifacts for `govmomi` and its dependencies are present in `/usr/share/licenses/govmomi`.

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
