### PR TITLE
minor update to SDK dependencies

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -571,9 +571,9 @@ RUN \
   mkdir -p /usr/libexec/tools /usr/share/licenses/govmomi && \
   chown -R builder:builder /usr/libexec/tools /usr/share/licenses/govmomi
 
-ARG GOVMOMIVER="0.27.0"
-ARG GOVMOMISHORTCOMMIT="086bb561"
-ARG GOVMOMIDATE="2021-10-14T20:30:09Z"
+ARG GOVMOMIVER="0.27.1"
+ARG GOVMOMISHORTCOMMIT="6209be5b"
+ARG GOVMOMIDATE="2021-10-15T15:35:40Z"
 
 USER builder
 WORKDIR ${GOPATH}/src/github.com/vmware/govmomi

--- a/Dockerfile
+++ b/Dockerfile
@@ -370,7 +370,7 @@ RUN \
 ARG ARCH
 ARG HOST_ARCH
 ARG VENDOR="bottlerocket"
-ARG RUSTVER="1.56.0"
+ARG RUSTVER="1.56.1"
 
 USER builder
 WORKDIR /home/builder

--- a/Dockerfile
+++ b/Dockerfile
@@ -446,7 +446,7 @@ FROM sdk-libc as sdk-go
 
 ARG ARCH
 ARG TARGET="${ARCH}-bottlerocket-linux-gnu"
-ARG GOVER="1.16.9"
+ARG GOVER="1.16.10"
 
 USER root
 RUN dnf -y install golang

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 ARCH ?= $(shell uname -m)
 HOST_ARCH ?= $(shell uname -m)
 
-VERSION := v0.23.0
+VERSION := v0.23.1
 
 SDK_TAG := bottlerocket/sdk-$(ARCH):$(VERSION)-$(HOST_ARCH)
 TOOLCHAIN_TAG := bottlerocket/toolchain-$(ARCH):$(VERSION)-$(HOST_ARCH)

--- a/hashes/go
+++ b/hashes/go
@@ -1,2 +1,2 @@
-# https://golang.org/dl/go1.16.9.src.tar.gz
-SHA512 (go1.16.9.src.tar.gz) = e1c02ac64fcc13b94bb160c9129d5fcfa4a486df069e4f5a42b5d5827e0c82105a957a92926a1e4802e37fd5a148ffcc015e244a31367fd68cfe30c90d2de385
+# https://golang.org/dl/go1.16.10.src.tar.gz
+SHA512 (go1.16.10.src.tar.gz) = d12753bd7973beb7ab047a189bd0d7132b5ab8c35e943b12388289d59f9becaefb858d37cfcb808c1e12f3e06c883ef170d98ed99449e9beda636cab9bfff2b6

--- a/hashes/govmomi
+++ b/hashes/govmomi
@@ -1,2 +1,2 @@
-# https://github.com/vmware/govmomi/archive/v0.27.0.tar.gz#/govmomi-0.27.0.tar.gz
-SHA512 (govmomi-0.27.0.tar.gz) = 696db77edbc77fc7068e678a858d4c28cab8e7750b9cf8f2ba81704e4d8b6a0e046b49b05cd356c2e6b9575c6995697f5ffc190b1af1968f590a11a8bc2276d0
+# https://github.com/vmware/govmomi/archive/v0.27.1.tar.gz#/govmomi-0.27.1.tar.gz
+SHA512 (govmomi-0.27.1.tar.gz) = 2135fb8ebc69e3c34881fb3ba6467cf32a4dcb2b6ccfa8f43ae9baef50fd0b11b29c1bdefd5c8a90f8aed28f210604ff74e24179a1f3e1b668b0edcce06c22b3

--- a/hashes/rust
+++ b/hashes/rust
@@ -1,6 +1,6 @@
-# https://static.rust-lang.org/dist/rustc-1.56.0-src.tar.xz
-SHA512 (rustc-1.56.0-src.tar.xz) = 2daa365524b47dcc48e49a0e9c8c45988af44c0845e2695dc5053f18e768e49acf3dbdd77f808dbf260546ef608eb47c593544012dd05675cb7e6b6223900315
-### See https://github.com/rust-lang/rust/blob/1.56.0/src/stage0.txt for what to use below. ###
+# https://static.rust-lang.org/dist/rustc-1.56.1-src.tar.xz
+SHA512 (rustc-1.56.1-src.tar.xz) = 193468e211cde9ebc5f6e30b8e3733b79bd8710fe6dd45c7ed8d4392f91010d30466787afd4d0b2041cd7dd994924fee8ad111048824e248bd994959e55bf15f
+### See https://github.com/rust-lang/rust/blob/1.56.1/src/stage0.txt for what to use below. ###
 # https://static.rust-lang.org/dist/2021-09-09/rust-std-1.55.0-x86_64-unknown-linux-gnu.tar.xz
 SHA512 (rust-std-1.55.0-x86_64-unknown-linux-gnu.tar.xz) = 88832a54efe6591bb2191e5a43c81639d590b012f51d5e086bed66ac4fce51bb93f6104bfbbca87614dfbfba78a096c2cdd9ad194e44bb4d409530a8f929d905
 # https://static.rust-lang.org/dist/2021-09-09/rustc-1.55.0-x86_64-unknown-linux-gnu.tar.xz


### PR DESCRIPTION
**Issue number:**

#61 

**Description of changes:**

This is a minor point release **(v0.23.1)** containing mostly security fixes.

* Rust: **1.56.0 → 1.56.1**
* Go: **1.16.9 → 1.16.10**
* govc: **0.27.0 → 0.27.1**

**Testing done:**

- [x] Build SDK (and Bottlerocket) `x86_64` on `x86_64`
- [x] Build SDK (and Bottlerocket) `aarch64` on `x86_64`
- [x] Build SDK (and Bottlerocket) `aarch64` on `aarch64`
- [x] Build SDK (and Bottlerocket) `x86_64` on `aarch64`

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
