### PR TITLE
Pull base images from Amazon ECR Public

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM fedora:35 as base
+FROM public.ecr.aws/docker/library/fedora:35 as base
 
 # Everything we need to build our SDK and packages.
 RUN \
@@ -22,7 +22,7 @@ COPY ./sdk-fetch /usr/local/bin
 
 # We expect our C cross-compiler to be used on other distros for building kernel
 # modules, so we build it with an older glibc for compatibility.
-FROM ubuntu:16.04 as compat
+FROM public.ecr.aws/docker/library/ubuntu:16.04 as compat
 RUN \
   apt-get update && \
   apt-get -y dist-upgrade && \


### PR DESCRIPTION
**Description of changes:**

This pulls images from Amazon ECR Public now that Docker Official Images are available there.

**Testing done:**

_Tested in conjunction with #69._

- [x] Build SDK (and Bottlerocket) `x86_64` on `x86_64`
- [x] Build SDK (and Bottlerocket) `aarch64` on `x86_64`
- [x] Build SDK (and Bottlerocket) `aarch64` on `aarch64`
- [x] Build SDK (and Bottlerocket) `x86_64` on `aarch64`


**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
