### PR TITLE
Add bootconfig CLI tool

### DIFF
--- a/hashes/kernel
+++ b/hashes/kernel
@@ -1,0 +1,2 @@
+# https://cdn.kernel.org/pub/linux/kernel/v5.x/linux-5.10.109.tar.xz
+SHA512 (linux-5.10.109.tar.xz) = 0a035a72096c6076c47c93c885dbbf0f59315ea7acf1289305a98d6d585d9622115b38fb32634cc72929fd200eb7a4f5debb076c681afec999dbe49ef67438e2


### PR DESCRIPTION
**Description of changes:**
```
This adds the `bootconfig` CLI tool to the SDK to enable users to use it
without needing to compile it themselves.  Though the tool doesn't get
updated often, it does pull in headers from the kernel proper.  The tool
provided here matches up with the Bottlerocket kernel version at this
time (5.10.102).
```


**Testing done:**

- [x]  Ensure that the tool and licenses end up in the SDK container
- [x] Ensure it can append a bootconfig file to a given initrd


**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
