### PR TITLE
add AWS CLI and clean up weak deps, caches

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@ RUN \
   dnf makecache && \
   dnf -y update && \
   dnf -y groupinstall "C Development Tools and Libraries" && \
-  dnf -y install \
+  dnf -y install --setopt=install_weak_deps=False \
     rpmdevtools dnf-plugins-core createrepo_c \
     cmake git meson perl-ExtUtils-MakeMaker python which \
     bc hostname intltool gperf kmod rsync wget openssl \
@@ -816,7 +816,8 @@ RUN \
     java-11-openjdk-devel maven-openjdk11 maven-local \
     maven-clean-plugin maven-shade-plugin \
     efitools gnutls-utils gnupg-pkcs11-scd nss-tools \
-    openssl-pkcs11 pesign python3-virt-firmware sbsigntools
+    openssl-pkcs11 pesign python3-virt-firmware sbsigntools && \
+  dnf clean all
 
 # =^..^=   =^..^=   =^..^=   =^..^=   =^..^=   =^..^=   =^..^=   =^..^=   =^..^=
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -816,7 +816,8 @@ RUN \
     java-11-openjdk-devel maven-openjdk11 maven-local \
     maven-clean-plugin maven-shade-plugin \
     efitools gnutls-utils gnupg-pkcs11-scd nss-tools \
-    openssl-pkcs11 pesign python3-virt-firmware sbsigntools && \
+    openssl-pkcs11 pesign python3-virt-firmware sbsigntools \
+    awscli && \
   dnf clean all
 
 # =^..^=   =^..^=   =^..^=   =^..^=   =^..^=   =^..^=   =^..^=   =^..^=   =^..^=


### PR DESCRIPTION
**Issue number:**
N/A


**Description of changes:**
Add the AWS CLI, for use with a helper script to generate certificates for Secure Boot support.

Exclude weak dependencies in the initial `dnf install` transaction, to avoid installing unnecessary software, and clean up the cache afterwards. 

**Testing done:**
Verified that I could use AWS CLI from the SDK for the helper script. Confirmed that a full distro build with the removed packages succeeded.

Added packages:
```
awscli
python3-botocore
python3-docutils
python3-jmespath
python3-pyasn1
python3-pyyaml
python3-rsa
python3-s3transfer
```

Removed packages:
```
elfutils-debuginfod-client-devel
http-parser
koji
libgit2
libssh2
libxkbcommon
perl-CPAN-Meta
perl-CPAN-Meta-Requirements
perl-CPAN-Meta-YAML
perl-devel
perl-Devel-PPPort
perl-doc
perl-Encode-Locale
perl-ExtUtils-Constant
perl-I18N-Langinfo
perl-JSON-PP
perl-Math-BigInt
perl-Math-Complex
python3-babel
python3-decorator
python3-gssapi
python3-koji
python3-pygit2
python3-pyparsing
python3-pytz
python3-requests-gssapi
python3-rpmautospec
qrencode-libs
systemd-networkd
systemd-resolved
systemtap-sdt-devel
xkeyboard-config
```

`/var/cache/dnf` is also smaller:
```
Before: 234M
After: 7.9M
```

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
