### PR TITLE
Add clippy to tools in rust configs

### DIFF
--- a/configs/rust/config-aarch64.toml.in
+++ b/configs/rust/config-aarch64.toml.in
@@ -13,7 +13,7 @@ compiler-docs = false
 vendor = true
 submodules = false
 extended = true
-tools = ["cargo"]
+tools = ["cargo", "clippy"]
 
 [rust]
 channel = "stable"

--- a/configs/rust/config-x86_64.toml.in
+++ b/configs/rust/config-x86_64.toml.in
@@ -13,7 +13,7 @@ compiler-docs = false
 vendor = true
 submodules = false
 extended = true
-tools = ["cargo"]
+tools = ["cargo", "clippy"]
 
 [rust]
 channel = "stable"


### PR DESCRIPTION
<!--
Tips:
- Please read the CONTRIBUTING document to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->

**Issue number:**

https://github.com/bottlerocket-os/bottlerocket/issues/2704

**Description of changes:**

Added `clippy` to the `tools` vec in the Rust configs so linting can be done via the SDK instead of local `cargo` installs.

**Testing done:**

Built x86_64 and aarch64 SDK and toolchain on x86_64 host and aarch64 host

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
