### PR TITLE
sdk-go: Upgrades to latest Go 1.19 and `govc` compiled with Go

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -519,7 +519,7 @@ FROM sdk-libc as sdk-go
 
 ARG ARCH
 ARG TARGET="${ARCH}-bottlerocket-linux-gnu"
-ARG GOVER="1.19.4"
+ARG GOVER="1.19.6"
 
 USER root
 RUN dnf -y install golang

--- a/Dockerfile
+++ b/Dockerfile
@@ -731,9 +731,9 @@ RUN \
   mkdir -p /usr/libexec/tools /usr/share/licenses/govmomi && \
   chown -R builder:builder /usr/libexec/tools /usr/share/licenses/govmomi
 
-ARG GOVMOMIVER="0.29.0"
-ARG GOVMOMISHORTCOMMIT="69ac849"
-ARG GOVMOMIDATE="2022-07-06T16:00:32Z"
+ARG GOVMOMIVER="0.30.2"
+ARG GOVMOMISHORTCOMMIT="9078b0b"
+ARG GOVMOMIDATE="2023-02-01T04:38:23Z"
 
 USER builder
 WORKDIR ${GOPATH}/src/github.com/vmware/govmomi

--- a/hashes/go
+++ b/hashes/go
@@ -1,2 +1,2 @@
-# https://go.dev/dl/go1.19.4.src.tar.gz
-SHA512 (go1.19.4.src.tar.gz) = 00866e171d73170583e292439beecdaaee1b8fa907b6ab03013390b0cd7eaebfbe8cb9f9222f1af86933b50602e584677bc3aa25993c02d07a11625a62db263b
+# https://go.dev/dl/go1.19.6.src.tar.gz
+SHA512 (go1.19.6.src.tar.gz) = f817ea6bcd83b60d9bf2ae9d0afdaa21651ac6cf5a32c260f40a691cd0ccce556ec9a483e10fa1a5dc244d6ea512407f5dae9c99ac004393b196a80284e63977

--- a/hashes/govmomi
+++ b/hashes/govmomi
@@ -1,2 +1,2 @@
-# https://github.com/vmware/govmomi/archive/v0.29.0.tar.gz#/govmomi-0.29.0.tar.gz
-SHA512 (govmomi-0.29.0.tar.gz) = f43cdb8333775689ede39bc2f488433de1a8c6be9cffd534f50023557f5fde3bddc6f2ead88d9f23d0de3a7ed16191bc4daa1e7f31dceb80055feb202c94ab7e
+# https://github.com/vmware/govmomi/archive/v0.30.2.tar.gz#/govmomi-0.30.2.tar.gz
+SHA512 (govmomi-0.30.2.tar.gz) = 19128ee73138ee8528678e577a6c03296a8782eaf5828cc1674bd42f793f0adb0121a1a38e039eeb130f89264d4ee31229cb61c5d6210199f92ad95b6f1e4661


### PR DESCRIPTION
**Issue number:**

N/a - upgrade for `go-sdk` to latest Go 1.19: https://go.dev/dl/

**Testing done:**

Build local SDK with `make`. Building local arm and x86 bottlerocket images now

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
