### PR TITLE
Dependency updates

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -837,7 +837,7 @@ RUN make install
 
 FROM sdk as sdk-e2fsprogs
 
-ARG E2FSPROGS_VER="1.46.5"
+ARG E2FSPROGS_VER="1.46.6"
 
 USER builder
 WORKDIR /home/builder

--- a/Dockerfile
+++ b/Dockerfile
@@ -84,15 +84,15 @@ RUN \
   git config --global user.name "Builder" && \
   git config --global user.email "builder@localhost"
 
-ARG BRVER="2022.11"
-ARG KVER="5.10.155"
+ARG BRVER="2022.11.1"
+ARG KVER="5.10.162"
 
 WORKDIR /home/builder
 COPY ./hashes/buildroot ./hashes
 RUN \
   sdk-fetch hashes && \
-  tar xf buildroot-${BRVER}.tar.gz && \
-  rm buildroot-${BRVER}.tar.gz && \
+  tar xf buildroot-${BRVER}.tar.xz && \
+  rm buildroot-${BRVER}.tar.xz && \
   mv buildroot-${BRVER} buildroot && \
   mv queue.h queue.h?rev=1.70
 
@@ -107,7 +107,7 @@ RUN \
 
 FROM toolchain as toolchain-gnu
 ARG ARCH
-ARG KVER="5.10.155"
+ARG KVER="5.10.162"
 RUN \
   make O=output/${ARCH}-gnu defconfig BR2_DEFCONFIG=configs/sdk_${ARCH}_gnu_defconfig && \
   make O=output/${ARCH}-gnu toolchain && \
@@ -131,7 +131,7 @@ RUN \
 
 FROM toolchain as toolchain-musl
 ARG ARCH
-ARG KVER="5.10.155"
+ARG KVER="5.10.162"
 RUN \
   make O=output/${ARCH}-musl defconfig BR2_DEFCONFIG=configs/sdk_${ARCH}_musl_defconfig && \
   make O=output/${ARCH}-musl toolchain && \
@@ -165,7 +165,7 @@ FROM base as sdk
 USER root
 
 ARG ARCH
-ARG KVER="5.10.155"
+ARG KVER="5.10.162"
 
 WORKDIR /
 
@@ -211,7 +211,7 @@ ARG SYSROOT="/${TARGET}/sys-root"
 ARG CFLAGS="-O2 -g -Wp,-D_GLIBCXX_ASSERTIONS -fstack-clash-protection"
 ARG CXXFLAGS="${CFLAGS}"
 ARG CPPFLAGS=""
-ARG KVER="5.10.155"
+ARG KVER="5.10.162"
 
 WORKDIR /home/builder/glibc/build
 RUN \
@@ -493,7 +493,7 @@ FROM sdk-libc as sdk-bootconfig
 
 USER root
 
-ARG KVER="5.10.155"
+ARG KVER="5.10.162"
 
 RUN \
   mkdir -p /usr/libexec/tools /usr/share/licenses/bootconfig && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -417,7 +417,7 @@ RUN \
 ARG ARCH
 ARG HOST_ARCH
 ARG VENDOR="bottlerocket"
-ARG RUSTVER="1.66.1"
+ARG RUSTVER="1.67.1"
 
 USER builder
 WORKDIR /home/builder

--- a/Dockerfile
+++ b/Dockerfile
@@ -280,7 +280,7 @@ RUN make install
 RUN \
   install -p -m 0644 -Dt ${SYSROOT}/usr/share/licenses/musl COPYRIGHT
 
-ARG LLVMVER="15.0.6"
+ARG LLVMVER="15.0.7"
 
 USER builder
 WORKDIR /home/builder

--- a/hashes/buildroot
+++ b/hashes/buildroot
@@ -1,5 +1,5 @@
-# https://buildroot.org/downloads/buildroot-2022.11.tar.gz
-SHA512 (buildroot-2022.11.tar.gz) = 467241a472b4eef484e756100f348214c469ae0bed31afa8536681816742b2ac00a0b4ca50f14829d1dfc6fdfba75a4885555f9aeab47b0cde3226d5086d5687
+# https://buildroot.org/downloads/buildroot-2022.11.1.tar.xz
+SHA512 (buildroot-2022.11.1.tar.xz) = 2c99a22c1f218e74411ca227ac033aac1cfcd175af8558ea0a35527cdcb9ebcb5b8359be50932279cd99b68bf2597451215a019e81334577310e6c99139e8aab
 # https://mirrors.kernel.org/gnu/binutils/binutils-2.38.tar.xz
 SHA512 (binutils-2.38.tar.xz) = 8bf0b0d193c9c010e0518ee2b2e5a830898af206510992483b427477ed178396cd210235e85fd7bd99a96fc6d5eedbeccbd48317a10f752b7336ada8b2bb826d
 # https://mirrors.kernel.org/gnu/bison/bison-3.8.2.tar.xz
@@ -16,8 +16,8 @@ SHA512 (gmp-6.2.1.tar.xz) = c99be0950a1d05a0297d65641dd35b75b74466f7bf03c9e8a998
 SHA512 (isl-0.25.tar.xz) = 81ac6b404a71e146bb705efe647ecf3bee19c3254f534cb44228cec13ffc7a33d7d58b980106dbb120ffdc557403d966619e219328edd0a4b3cbc4ac66acb255
 # https://musl.libc.org/releases/musl-1.2.3.tar.gz
 SHA512 (musl-1.2.3.tar.gz) = 9332f713d3eb7de4369bc0327d99252275ee52abf523ee34b894b24a387f67579787f7c72a46cf652e090cffdb0bc3719a4e7b84dca66890b6a37f12e8ad089c
-# https://cdn.kernel.org/pub/linux/kernel/v5.x/linux-5.10.155.tar.xz
-SHA512 (linux-5.10.155.tar.xz) = fc763f7854ed5e8964fee2acc2f521caa215cbfa76dd7a054173fcf37f74ef543820e7b026c0ee2c01c178eb22c89ad334ec9559950772ec278d78d95b32d33c
+# https://cdn.kernel.org/pub/linux/kernel/v5.x/linux-5.10.162.tar.xz
+SHA512 (linux-5.10.162.tar.xz) = 941c7ddd7c27f49b4491e1c8fbf1efedcbac50b48ed8836ec91091ead69723f820a61bfda795378dcc728a782d2206189903333e83e255b723eec01157bbb0bb
 # https://mirrors.kernel.org/gnu/m4/m4-1.4.19.tar.xz
 SHA512 (m4-1.4.19.tar.xz) = 47f595845c89709727bda0b3fc78e3188ef78ec818965b395532e7041cabe9e49677ee4aca3d042930095a7f8df81de3da1026b23b6897be471f6cf13ddd512b
 # https://mirrors.kernel.org/gnu/mpc/mpc-1.2.1.tar.gz

--- a/hashes/e2fsprogs
+++ b/hashes/e2fsprogs
@@ -1,2 +1,2 @@
-# https://mirrors.edge.kernel.org/pub/linux/kernel/people/tytso/e2fsprogs/v1.46.5/e2fsprogs-1.46.5.tar.xz
-SHA512 (e2fsprogs-1.46.5.tar.xz) = 53282e1c524f62a95012b1aceef296d494f5238c82c9b08b29fbe6a803dbf7ccfdcd9124eb2f11fe2ff9de26387c78751a92c3217ca414f6db6242098a72d3fa
+# https://mirrors.edge.kernel.org/pub/linux/kernel/people/tytso/e2fsprogs/v1.46.6/e2fsprogs-1.46.6.tar.xz
+SHA512 (e2fsprogs-1.46.6.tar.xz) = aca5ef77e36885ce9ce2995d9fae5d278c33e276e74f2a73977380f3e1cf1b3bd115fe6199e44a2f79a2827ba985b5554b8d898e88b7d04387fbba659a08e771

--- a/hashes/kernel
+++ b/hashes/kernel
@@ -1,2 +1,2 @@
-# https://cdn.kernel.org/pub/linux/kernel/v5.x/linux-5.10.155.tar.xz
-SHA512 (linux-5.10.155.tar.xz) = fc763f7854ed5e8964fee2acc2f521caa215cbfa76dd7a054173fcf37f74ef543820e7b026c0ee2c01c178eb22c89ad334ec9559950772ec278d78d95b32d33c
+# https://cdn.kernel.org/pub/linux/kernel/v5.x/linux-5.10.162.tar.xz
+SHA512 (linux-5.10.162.tar.xz) = 941c7ddd7c27f49b4491e1c8fbf1efedcbac50b48ed8836ec91091ead69723f820a61bfda795378dcc728a782d2206189903333e83e255b723eec01157bbb0bb

--- a/hashes/libunwind
+++ b/hashes/libunwind
@@ -1,8 +1,8 @@
-# https://github.com/llvm/llvm-project/releases/download/llvmorg-15.0.6/llvm-15.0.6.src.tar.xz
-SHA512 (llvm-15.0.6.src.tar.xz) = 91b53674c140f8eda6e8373a9e3ea013807236e98702b6666f3b4144d95d97dcfa0a59591ab74aa7a320c32f88d579a585dc5a6db6666f1754f68493f95cff1e
-# https://github.com/llvm/llvm-project/releases/download/llvmorg-15.0.6/libcxx-15.0.6.src.tar.xz
-SHA512 (libcxx-15.0.6.src.tar.xz) = 9ad8bc3d547e3f5e7fe123a9a1e39be523dff71c10feaed773c6a2698fbba54fb8c89760409e3b982007787c63ce7ae410fc1fe05aa7b3cb284589f85cb3bbc8
-# https://github.com/llvm/llvm-project/releases/download/llvmorg-15.0.6/libunwind-15.0.6.src.tar.xz
-SHA512 (libunwind-15.0.6.src.tar.xz) = 9e888d66112ee2b275cad03c102a2c07ddfd01167a0c88fab17a4a190008f5c1a7a21c7e78b449f48321bc920f9fb8d64508075e4e175617c8cc0b4aeb343c3e
-# https://github.com/llvm/llvm-project/releases/download/llvmorg-15.0.6/cmake-15.0.6.src.tar.xz
-SHA512 (cmake-15.0.6.src.tar.xz) = a078b9b426515414dae41c8732d7cd955e8ddc9638b4ba9c7dd0925db68e5ea760096f08fd7e1cb9d55b6d73da75f9b4318a2fac36d7aa64f47536ac383b3edc
+# https://github.com/llvm/llvm-project/releases/download/llvmorg-15.0.7/llvm-15.0.7.src.tar.xz
+SHA512 (llvm-15.0.7.src.tar.xz) = ed8d565515b1bc6164e4ff06d3388ba92e332850305496fd65db9adf1ec87bd9dd1bfde49dd41be5d5216289efc72bfd287cd7392f2bba80b740d4c314c749e5
+# https://github.com/llvm/llvm-project/releases/download/llvmorg-15.0.7/libcxx-15.0.7.src.tar.xz
+SHA512 (libcxx-15.0.7.src.tar.xz) = 2c47cb93867e137a9bc8dd273335bb153e2353eb308635c2264be962fa421ddc10eb3ec8b5800204fc1f8ee51abbe0c526665300cb7e94e9f8b7e9891b5c5b64
+# https://github.com/llvm/llvm-project/releases/download/llvmorg-15.0.7/libunwind-15.0.7.src.tar.xz
+SHA512 (libunwind-15.0.7.src.tar.xz) = ebc73a5c68615a4462f4d05040a68a28e92b144d8c66d3fb2271cf6fff60a0adb1b913c8e520717ac2f6bd9e4b44c16d9461ef70502975975d1779e2b27a9392
+# https://github.com/llvm/llvm-project/releases/download/llvmorg-15.0.7/cmake-15.0.7.src.tar.xz
+SHA512 (cmake-15.0.7.src.tar.xz) = 85097a6eaee0df004567905f7e5ce8ca02e3b46c6fc66fa552fe99734642e6ee61685de4e5e6e8b505963334d7b91d98ecd9c5870e6bdd3f0018ee5b963ffa96

--- a/hashes/rust
+++ b/hashes/rust
@@ -1,15 +1,15 @@
-# https://static.rust-lang.org/dist/rustc-1.66.1-src.tar.xz
-SHA512 (rustc-1.66.1-src.tar.xz) = 1944c024c603140d0a9236043a3bd1d0d211dd8d368d6d82a3a620f1ff43b29624755b0943f2b38b40a188c7eee77a840238ea757eaf435e2a3fa6a0e6b82832
-### See https://github.com/rust-lang/rust/blob/1.66.1/src/stage0.json for what to use below. ###
-# https://static.rust-lang.org/dist/2022-11-03/rust-std-1.65.0-x86_64-unknown-linux-gnu.tar.xz
-SHA512 (rust-std-1.65.0-x86_64-unknown-linux-gnu.tar.xz) = 409d1466fa1b457bba20424509b6a7dc8864c64c05061f62b09cdc977d2e3967fdbe543ed73703736d525dd35ef8e74ca7304d4efa13622adf835172a65867d1
-# https://static.rust-lang.org/dist/2022-11-03/rustc-1.65.0-x86_64-unknown-linux-gnu.tar.xz
-SHA512 (rustc-1.65.0-x86_64-unknown-linux-gnu.tar.xz) = 52601c4fb5057a55f504585f804e0c275d1268c4acd9ba5c5948b5e2d2d2de9ffee499810fe0bac8cd3773fadbdc049ecc55be606675562374a99c0fa06a8cb0
-# https://static.rust-lang.org/dist/2022-11-03/cargo-1.65.0-x86_64-unknown-linux-gnu.tar.xz
-SHA512 (cargo-1.65.0-x86_64-unknown-linux-gnu.tar.xz) = b5735c8c39d04212e1ff9c214b15d76370ee10b0630490b3596ba6fbd5ad4025921d7d5e54177a7ba19bbefe4832f3741ee71eb90aa722d5fed161150e794258
-# https://static.rust-lang.org/dist/2022-11-03/rust-std-1.65.0-aarch64-unknown-linux-gnu.tar.xz
-SHA512 (rust-std-1.65.0-aarch64-unknown-linux-gnu.tar.xz) = 36af2e94c92faca1544d628d80bd2085ad678ed4e380f38a7219d714cb7586e1fbeebafe7702694a3fe0c44c1cc55a645f415fb100a12e4bed468507147a423a
-# https://static.rust-lang.org/dist/2022-11-03/rustc-1.65.0-aarch64-unknown-linux-gnu.tar.xz
-SHA512 (rustc-1.65.0-aarch64-unknown-linux-gnu.tar.xz) = f9c38b7b70ce9d34c9b288bb440e4c2a63e9e33524c01d04b9c349f468a2def70feced8e2500a8299c571ea701a57adfc0ac197805a37fa08940e0e25b405248
-# https://static.rust-lang.org/dist/2022-11-03/cargo-1.65.0-aarch64-unknown-linux-gnu.tar.xz
-SHA512 (cargo-1.65.0-aarch64-unknown-linux-gnu.tar.xz) = ef774f892fcfc19c9598ae929d0da67a058e158651b94006f8d31028701cc16e6ccf2a4120eb71cd1fd7833922bd7ffd09739976565d4e398a3294c6a1dac0d8
+# https://static.rust-lang.org/dist/rustc-1.67.1-src.tar.xz
+SHA512 (rustc-1.67.1-src.tar.xz) = 42d77ee93b168ae139b026138fb48d925624ff436a836aa97ee235f870e61ea11643b0cf7ad20bcafda774c6cd3855a4bc10a2e2ed1c4d82c6f15158963b304d
+### See https://github.com/rust-lang/rust/blob/1.67.1/src/stage0.json for what to use below. ###
+# https://static.rust-lang.org/dist/2023-01-10/rust-std-1.66.1-x86_64-unknown-linux-gnu.tar.xz
+SHA512 (rust-std-1.66.1-x86_64-unknown-linux-gnu.tar.xz) = e1c51b14c83eaadcd1625d3661e63695cedd9fe0758c16629bd9775454c95739324eebd7fc73c42b249a416b79c161ad37e7d91af2b2785c89244a96d9403597
+# https://static.rust-lang.org/dist/2023-01-10/rustc-1.66.1-x86_64-unknown-linux-gnu.tar.xz
+SHA512 (rustc-1.66.1-x86_64-unknown-linux-gnu.tar.xz) = 7dd43c63c2f9c0d90a3ec3d41c2a3d8a02f3f9eab6f423eddedf6a74553b9448a25cb784b7a109e47fa773c0c2b212ed06c20dc7d7e33aa355dd9e4399aebccf
+# https://static.rust-lang.org/dist/2023-01-10/cargo-1.66.1-x86_64-unknown-linux-gnu.tar.xz
+SHA512 (cargo-1.66.1-x86_64-unknown-linux-gnu.tar.xz) = 9c93f772b1e3d2d7e871de3d5ed0d96d4d180d5bfbceff056b0b652ac7cefbcf98a5cc8261a7515f8628d9b9ab095779f096abed451f7fb95a7292855d2f4eed
+# https://static.rust-lang.org/dist/2023-01-10/rust-std-1.66.1-aarch64-unknown-linux-gnu.tar.xz
+SHA512 (rust-std-1.66.1-aarch64-unknown-linux-gnu.tar.xz) = 72d307deec5f154aa3cdbf94f40483dd53605908ae142365e212c9562b41c9c023c99fec2efab0c9eef3f99663f5d6e0434e180866792c8411b3723b635d463e
+# https://static.rust-lang.org/dist/2023-01-10/rustc-1.66.1-aarch64-unknown-linux-gnu.tar.xz
+SHA512 (rustc-1.66.1-aarch64-unknown-linux-gnu.tar.xz) = a8e9efb9e99947a18a420edbabdddba7b36edcd93b2d6a5de342dbaa4d210232cc2790f43d3261032e5f61eba7e6a3b289ff9e5d3e16898d7b93aa275d7c7978
+# https://static.rust-lang.org/dist/2023-01-10/cargo-1.66.1-aarch64-unknown-linux-gnu.tar.xz
+SHA512 (cargo-1.66.1-aarch64-unknown-linux-gnu.tar.xz) = d540403e7f0f8c9ecc17905b5bf74c4c9dd9dea694b05f8a6ce55b5dc65874a919790074a8b60d24b31ced3a4d6d41f4fde7651a96870752906f30115d61af8b


### PR DESCRIPTION
**Description of changes:**

* Rust: **1.66.1 → 1.67.1**
* Buildroot: **2022.11 → 2022.11.1**
* Linux kernel: **5.10.155 → 5.10.162**
* e2fsprogs: **1.46.5 → 1.46.6**
* LLVM: **15.0.6 → 15.0.7**

**Testing done:**

- [x] Build SDK (and Bottlerocket) `x86_64` on `x86_64`
- [x] Build SDK (and Bottlerocket) `aarch64` on `x86_64`
- [x] Build SDK (and Bottlerocket) `aarch64` on `aarch64`
- [x] Build SDK (and Bottlerocket) `x86_64` on `aarch64`



**Testing done:**



**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
