### PR TITLE
sdk-fetch: Allow upstream source fallback

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -84,6 +84,7 @@ RUN \
   git config --global user.name "Builder" && \
   git config --global user.email "builder@localhost"
 
+ARG UPSTREAM_SOURCE_FALLBACK
 ARG BRVER="2022.11.1"
 ARG KVER="5.10.162"
 
@@ -165,6 +166,7 @@ FROM base as sdk
 USER root
 
 ARG ARCH
+ARG UPSTREAM_SOURCE_FALLBACK
 ARG KVER="5.10.162"
 
 WORKDIR /

--- a/Makefile
+++ b/Makefile
@@ -2,6 +2,7 @@ TOP := $(dir $(abspath $(firstword $(MAKEFILE_LIST))))
 
 ARCH ?= $(shell uname -m)
 HOST_ARCH ?= $(shell uname -m)
+UPSTREAM_SOURCE_FALLBACK ?= false
 
 VERSION := $(shell cat $(TOP)VERSION)
 
@@ -16,7 +17,8 @@ sdk:
 		--target sdk-final \
 		--squash \
 		--build-arg ARCH=$(ARCH) \
-		--build-arg HOST_ARCH=$(HOST_ARCH)
+		--build-arg HOST_ARCH=$(HOST_ARCH) \
+		--build-arg UPSTREAM_SOURCE_FALLBACK=$(UPSTREAM_SOURCE_FALLBACK)
 
 toolchain:
 	@DOCKER_BUILDKIT=1 docker build . \
@@ -24,7 +26,8 @@ toolchain:
 		--target toolchain-final \
 		--squash \
 		--build-arg ARCH=$(ARCH) \
-		--build-arg HOST_ARCH=$(HOST_ARCH)
+		--build-arg HOST_ARCH=$(HOST_ARCH) \
+		--build-arg UPSTREAM_SOURCE_FALLBACK=$(UPSTREAM_SOURCE_FALLBACK)
 
 publish:
 	@test $${REGISTRY?not set!}

--- a/sdk-fetch
+++ b/sdk-fetch
@@ -1,8 +1,13 @@
 #!/bin/bash
 set -euxo pipefail
+UPSTREAM_SOURCE_FALLBACK="${UPSTREAM_SOURCE_FALLBACK:-'false'}"
 # shellcheck disable=SC2046
-curl --fail --remote-name-all --remote-time \
+if ! curl --fail --remote-name-all --remote-time \
     $(awk -F '[ ()]' '/^SHA512 \(/ {
         printf "https://cache.bottlerocket.aws/%s/%s/%s\n", $3, $6, $3
-    }' "$1")
+    }' "$1") \
+&& [[ "${UPSTREAM_SOURCE_FALLBACK}" == 'true' ]]; then
+    curl --fail --remote-name-all --remote-time --location \
+        $(awk '/^#\s((s)?ftp|http(s)?):\/\// {printf "%s\n", $2}' "$1")
+fi
 sha512sum --check "$1"


### PR DESCRIPTION
**Description of changes:**

This change allows for using upstream sources as a fallback when **UPSTREAM_SOURCE_FALLBACK** is set to 'true'.

**Testing done:**

Ran `make` with a versioned file not available in the lookaside cache which failed (as expected), then ran again with `make UPSTREAM_SOURCE_FALLBACK=true` which downloaded successfully.


**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
