### PR TITLE
Go: Upgrade to v1.19.8

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -518,7 +518,7 @@ FROM sdk-libc as sdk-go
 
 ARG ARCH
 ARG TARGET="${ARCH}-bottlerocket-linux-gnu"
-ARG GOVER="1.19.6"
+ARG GOVER="1.19.8"
 
 USER root
 RUN dnf -y install golang

--- a/hashes/go
+++ b/hashes/go
@@ -1,2 +1,2 @@
-# https://go.dev/dl/go1.19.6.src.tar.gz
-SHA512 (go1.19.6.src.tar.gz) = f817ea6bcd83b60d9bf2ae9d0afdaa21651ac6cf5a32c260f40a691cd0ccce556ec9a483e10fa1a5dc244d6ea512407f5dae9c99ac004393b196a80284e63977
+# https://go.dev/dl/go1.19.8.src.tar.gz
+SHA512 (go1.19.8.src.tar.gz) = d7ecbae3034211d7c64df4c0fce6894bae3e7e8de20bd2aa9f24b39cc040fa64d8a3bea311582cf4455a981dc3c8f319141f7f357db4eebd27d4451fee05727a


### PR DESCRIPTION
**Description of changes:**

Upgrades from Go 1.19.6 -> 1.19.8

Addresses 4 security issues in Go `parser` & `net` packages

https://groups.google.com/g/golang-announce/c/Xdv6JL9ENs8

**Testing done:**

Testing now!

- [x] Build SDK (and Bottlerocket) x86_64 on x86_64
- [x] Build SDK (and Bottlerocket) aarch64 on aarch64

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
