### PR TITLE
Go: Update to go 1.20.3

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -518,7 +518,7 @@ FROM sdk-libc as sdk-go
 
 ARG ARCH
 ARG TARGET="${ARCH}-bottlerocket-linux-gnu"
-ARG GOVER="1.19.8"
+ARG GOVER="1.20.3"
 
 USER root
 RUN dnf -y install golang

--- a/hashes/go
+++ b/hashes/go
@@ -1,2 +1,2 @@
-# https://go.dev/dl/go1.19.8.src.tar.gz
-SHA512 (go1.19.8.src.tar.gz) = d7ecbae3034211d7c64df4c0fce6894bae3e7e8de20bd2aa9f24b39cc040fa64d8a3bea311582cf4455a981dc3c8f319141f7f357db4eebd27d4451fee05727a
+# https://go.dev/dl/go1.20.3.src.tar.gz
+SHA512 (go1.20.3.src.tar.gz) = 47ebb3925956a3facef9e5e6f4efec3058e55632020ea247844c55b160d23e2be3880ea24dec2f73382a7c7858259896cbb7de1bb764c481c176bed479676029


### PR DESCRIPTION
**Issue number:**

N/A

**Description of changes:**

This updates the version of go used to the current 1.20.3 release.

**Testing done:**

- [x] Built on aarch64 and built bottlerocket using updated SDK

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
