### PR TITLE
add Docker CLI to the SDK

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -735,7 +735,7 @@ ARG GOVMOMISHORTCOMMIT="9078b0b"
 ARG GOVMOMIDATE="2023-02-01T04:38:23Z"
 
 USER builder
-WORKDIR ${GOPATH}/src/github.com/vmware/govmomi
+WORKDIR /home/builder/go/src/github.com/vmware/govmomi
 COPY ./hashes/govmomi /home/builder/hashes
 RUN \
   sdk-fetch /home/builder/hashes && \
@@ -755,6 +755,7 @@ RUN \
   export CGO_ENABLED=0 ; \
   export BUILD_VERSION_PKG="github.com/vmware/govmomi/govc/flags" ; \
   go build -mod=vendor -o /usr/libexec/tools/govc -ldflags " \
+    -s -w \
     -X ${BUILD_VERSION_PKG}.BuildVersion=${GOVMOMIVER} \
     -X ${BUILD_VERSION_PKG}.BuildCommit=${GOVMOMISHORTCOMMIT} \
     -X ${BUILD_VERSION_PKG}.BuildDate=${GOVMOMIDATE} \
@@ -969,7 +970,7 @@ COPY --chown=0:0 --from=sdk-rust-tools /usr/share/licenses/bottlerocket-license-
 COPY --chown=0:0 --from=sdk-rust-tools /usr/share/licenses/cargo-deny/ /usr/share/licenses/cargo-deny/
 
 # "sdk-govc" has the VMware govc tool and licenses.
-COPY --chown=0:0 --from=sdk-govc /usr/libexec/tools/ /usr/libexec/tools/
+COPY --chown=0:0 --from=sdk-govc /usr/libexec/tools/govc /usr/libexec/tools/
 COPY --chown=0:0 --from=sdk-govc /usr/share/licenses/govmomi/ /usr/share/licenses/govmomi/
 
 # "sdk-bootconfig" has the bootconfig tool

--- a/Dockerfile
+++ b/Dockerfile
@@ -763,6 +763,48 @@ RUN \
 
 # =^..^=   =^..^=   =^..^=   =^..^=   =^..^=   =^..^=   =^..^=   =^..^=   =^..^=
 
+FROM sdk-go as sdk-docker
+
+USER root
+RUN \
+  mkdir -p /usr/libexec/tools /usr/share/licenses/docker && \
+  chown -R builder:builder /usr/libexec/tools /usr/share/licenses/docker
+
+ARG DOCKERVER="20.10.21"
+ARG DOCKERCOMMIT="baeda1f82a10204ec5708d5fbba130ad76cfee49"
+ARG DOCKERIMPORT="github.com/docker/cli"
+ARG MOBYBIRTHDAY="2017-04-18T14:29:00.000000000+00:00"
+
+USER builder
+WORKDIR /home/builder/go/src/${DOCKERIMPORT}
+COPY ./hashes/docker /home/builder/hashes
+RUN \
+  sdk-fetch /home/builder/hashes && \
+  tar --strip-components=1 -xf cli-${DOCKERVER}.tar.gz && \
+  rm cli-${DOCKERVER}.tar.gz
+
+COPY --chown=0:0 --from=sdk-rust-tools /usr/libexec/tools/ /usr/libexec/tools/
+COPY ./configs/docker/clarify.toml .
+RUN \
+  cp -p LICENSE NOTICE /usr/share/licenses/docker && \
+  /usr/libexec/tools/bottlerocket-license-scan \
+    --clarify clarify.toml \
+    --spdx-data /usr/libexec/tools/spdx-data \
+    --out-dir /usr/share/licenses/docker/vendor \
+    go-vendor ./vendor
+
+RUN \
+  export CGO_ENABLED=0 ; \
+  go build -o /usr/libexec/tools/docker -ldflags " \
+    -s -w \
+    -X github.com/docker/cli/cli/version.Version=${DOCKERVER} \
+    -X github.com/docker/cli/cli/version.GitCommit=${DOCKERCOMMIT} \
+    -X github.com/docker/cli/cli/version.BuildTime=${MOBYBIRTHDAY} \
+    -X \"github.com/docker/cli/cli/version.PlatformName=Docker Engine - Community\" \
+    " ${DOCKERIMPORT}/cmd/docker
+
+# =^..^=   =^..^=   =^..^=   =^..^=   =^..^=   =^..^=   =^..^=   =^..^=   =^..^=
+
 FROM sdk as sdk-cpp
 
 ARG AWS_SDK_CPP_VER="1.9.332"
@@ -973,6 +1015,10 @@ COPY --chown=0:0 --from=sdk-rust-tools /usr/share/licenses/cargo-deny/ /usr/shar
 COPY --chown=0:0 --from=sdk-govc /usr/libexec/tools/govc /usr/libexec/tools/
 COPY --chown=0:0 --from=sdk-govc /usr/share/licenses/govmomi/ /usr/share/licenses/govmomi/
 
+# "sdk-docker" has the Docker CLI and licenses.
+COPY --chown=0:0 --from=sdk-docker /usr/libexec/tools/docker /usr/libexec/tools/
+COPY --chown=0:0 --from=sdk-docker /usr/share/licenses/docker/ /usr/share/licenses/docker/
+
 # "sdk-bootconfig" has the bootconfig tool
 COPY --chown=0:0 --from=sdk-bootconfig /usr/libexec/tools/bootconfig /usr/libexec/tools/bootconfig
 COPY --chown=0:0 --from=sdk-bootconfig /usr/share/licenses/bootconfig /usr/share/licenses/bootconfig
@@ -1051,6 +1097,11 @@ RUN \
 RUN \
   ln -sr /${ARCH}-bottlerocket-linux-gnu/sys-root/usr/share/licenses /usr/share/licenses/bottlerocket-sdk-gnu && \
   ln -sr /${ARCH}-bottlerocket-linux-musl/sys-root/usr/share/licenses /usr/share/licenses/bottlerocket-sdk-musl
+
+# Configure the Docker CLI.
+COPY \
+  ./configs/docker/docker-cli.json \
+  /home/builder/.docker/config.json
 
 # Reset permissions for `builder`.
 RUN chown builder:builder -R /home/builder

--- a/configs/docker/clarify.toml
+++ b/configs/docker/clarify.toml
@@ -1,0 +1,12 @@
+[clarify."github.com/docker/licensing"]
+expression = "Apache-2.0"
+license-files = [
+    { path = "LICENSE", hash = 0xd2f64213 },
+]
+skip-files = ["license.go", "model/license.go"]
+
+[clarify."sigs.k8s.io/yaml"]
+expression = "MIT AND BSD-3-Clause"
+license-files = [
+    { path = "LICENSE", hash = 0xcdf3ae00},
+]

--- a/configs/docker/docker-cli.json
+++ b/configs/docker/docker-cli.json
@@ -1,0 +1,1 @@
+{ "experimental": "enabled" }

--- a/hashes/docker
+++ b/hashes/docker
@@ -1,0 +1,2 @@
+# https://github.com/docker/cli/archive/v20.10.21.tar.gz/#cli-20.10.21.tar.gz
+SHA512 (cli-20.10.21.tar.gz) = 951100d75c833e1c844203fe86d73d25c3164eba4fce87cc05a0ac3691851fc5341c3b32ce3814dd61bd3700d8e8e1d045a7a5651c6dc5ddc0a39c58db9bd7b3


### PR DESCRIPTION
**Issue number:**
#108


**Description of changes:**
Add `docker` CLI to the SDK, based on the [Bottlerocket build](https://github.com/bottlerocket-os/bottlerocket/blob/develop/packages/docker-cli/docker-cli.spec#L32) and using the same sources.


**Testing done:**
Ran `docker` inside the SDK.
```
❯ docker run --rm -it --group-add $(getent group docker | awk -F: '{ print $3 }') -v /var/run/docker.sock:/var/run/docker.sock docker.io/bottlerocket/sdk-aarch64:v0.32.0-aarch64 bash

[builder@d4c5f3bb0f76 ~]$ docker image ls
REPOSITORY                                                         TAG                  IMAGE ID       CREATED        SIZE
bottlerocket/sdk-aarch64                                           v0.32.0-aarch64      ae595ac5e753   14 hours ago   3.27GB
...
```

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
