### PR TITLE
add cargo-make to the SDK

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -635,6 +635,24 @@ RUN cargo build --release --locked
 
 # =^..^=   =^..^=   =^..^=   =^..^=   =^..^=   =^..^=   =^..^=   =^..^=   =^..^=
 
+FROM sdk-cargo as sdk-cargo-make
+
+ARG MAKEVER="0.36.8"
+
+USER builder
+WORKDIR /home/builder
+COPY ./hashes/cargo-make ./hashes
+RUN \
+  sdk-fetch hashes && \
+  tar xf cargo-make-${MAKEVER}.tar.gz && \
+  rm cargo-make-${MAKEVER}.tar.gz && \
+  mv cargo-make-${MAKEVER} cargo-make
+
+WORKDIR /home/builder/cargo-make
+RUN cargo build --release --locked
+
+# =^..^=   =^..^=   =^..^=   =^..^=   =^..^=   =^..^=   =^..^=   =^..^=   =^..^=
+
 FROM sdk-cargo as sdk-rust-tools
 
 # Bring it all back together and run license-scan and cargo-deny on everything.
@@ -642,6 +660,10 @@ FROM sdk-cargo as sdk-rust-tools
 COPY --from=sdk-cargo-deny \
   /home/builder/cargo-deny \
   /home/builder/cargo-deny
+
+COPY --from=sdk-cargo-make \
+  /home/builder/cargo-make \
+  /home/builder/cargo-make
 
 COPY --from=sdk-license-tool \
   /home/builder/license-tool \
@@ -653,6 +675,10 @@ COPY --from=sdk-license-scan \
 
 COPY --chown=0:0 --from=sdk-cargo-deny \
   /home/builder/cargo-deny/target/release/cargo-deny \
+  /usr/libexec/tools/
+
+COPY --chown=0:0 --from=sdk-cargo-make \
+  /home/builder/cargo-make/target/release/cargo-make \
   /usr/libexec/tools/
 
 COPY --chown=0:0 --from=sdk-license-tool \
@@ -667,9 +693,13 @@ COPY --chown=0:0 --from=sdk-license-scan \
   /home/builder/license-scan/license-list-data/json/details \
   /usr/libexec/tools/spdx-data
 
-COPY --chown=1000:1000 \
-  LICENSE-APACHE LICENSE-MIT \
+COPY --chown=1000:1000 --from=sdk-cargo-deny \
+  /home/builder/cargo-deny/LICENSE-* \
   /usr/share/licenses/cargo-deny/
+
+COPY --chown=1000:1000 --from=sdk-cargo-make \
+  /home/builder/cargo-make/LICENSE \
+  /usr/share/licenses/cargo-make/
 
 COPY --chown=1000:1000 \
   COPYRIGHT LICENSE-APACHE LICENSE-MIT \
@@ -689,6 +719,20 @@ RUN \
     cargo --locked Cargo.toml
 
 COPY ./configs/cargo-deny/deny.toml .
+RUN \
+  /usr/libexec/tools/cargo-deny \
+    --all-features check --disable-fetch licenses bans sources
+
+WORKDIR /home/builder/cargo-make
+COPY ./configs/cargo-make/clarify.toml .
+RUN \
+  /usr/libexec/tools/bottlerocket-license-scan \
+    --clarify clarify.toml \
+    --spdx-data /usr/libexec/tools/spdx-data \
+    --out-dir /usr/share/licenses/cargo-make/vendor \
+    cargo --locked Cargo.toml
+
+COPY ./configs/cargo-make/deny.toml .
 RUN \
   /usr/libexec/tools/cargo-deny \
     --all-features check --disable-fetch licenses bans sources
@@ -967,6 +1011,7 @@ COPY --chown=0:0 --from=sdk-rust-tools /usr/libexec/tools/ /usr/libexec/tools/
 COPY --chown=0:0 --from=sdk-rust-tools /usr/share/licenses/bottlerocket-license-scan/ /usr/share/licenses/bottlerocket-license-scan/
 COPY --chown=0:0 --from=sdk-rust-tools /usr/share/licenses/bottlerocket-license-tool/ /usr/share/licenses/bottlerocket-license-tool/
 COPY --chown=0:0 --from=sdk-rust-tools /usr/share/licenses/cargo-deny/ /usr/share/licenses/cargo-deny/
+COPY --chown=0:0 --from=sdk-rust-tools /usr/share/licenses/cargo-make/ /usr/share/licenses/cargo-make/
 
 # "sdk-govc" has the VMware govc tool and licenses.
 COPY --chown=0:0 --from=sdk-govc /usr/libexec/tools/ /usr/libexec/tools/
@@ -1062,6 +1107,10 @@ WORKDIR /home/builder
 RUN \
   mkdir .netscape && \
   certutil -N --empty-password
+
+# Disable cargo make update checks for invocations within the SDK.
+RUN \
+  echo "export CARGO_MAKE_DISABLE_UPDATE_CHECK=1" >> .bashrc
 
 # =^..^=   =^..^=   =^..^=   =^..^=   =^..^=   =^..^=   =^..^=   =^..^=   =^..^=
 

--- a/configs/cargo-make/clarify.toml
+++ b/configs/cargo-make/clarify.toml
@@ -1,0 +1,186 @@
+[clarify.bstr]
+expression = "(MIT OR Apache-2.0) AND Unicode-DFS-2016"
+license-files = [
+    { path = "COPYING", hash = 0x278afbcf },
+    { path = "LICENSE-APACHE", hash = 0x24b54f4b },
+    { path = "LICENSE-MIT", hash = 0x462dee44 },
+    { path = "src/unicode/data/LICENSE-UNICODE", hash = 0x70f7339 },
+]
+
+[clarify.bzip2-sys]
+expression = "(MIT OR Apache-2.0) AND bzip2-1.0.6"
+license-files = [
+    { path = "LICENSE-APACHE", hash = 0x24b54f4b },
+    { path = "LICENSE-MIT", hash = 0x9374b940 },
+    { path = "bzip2-1.0.8/LICENSE", hash = 0x71e74485 },
+]
+
+[clarify.cargo-make]
+expression = "Apache-2.0"
+license-files = [
+    { path = "LICENSE", hash = 0xd9300aad },
+]
+skip-files = [
+    "docs/api/static.files/COPYRIGHT-000000008a1f0d17.txt",
+    "docs/api/static.files/FiraSans-LICENSE-000000004f3fb3ba.txt",
+    "docs/api/static.files/LICENSE-APACHE-00000000be5b60d4.txt",
+    "docs/api/static.files/LICENSE-MIT-00000000cc9db09c.txt",
+    "docs/api/static.files/NanumBarunGothic-LICENSE-000000008feec719.txt",
+    "docs/api/static.files/SourceCodePro-LICENSE-00000000fb612b27.txt",
+    "docs/api/static.files/SourceSerif4-LICENSE-00000000b79e562a.md",
+]
+
+[clarify.ci_info]
+expression = "Apache-2.0"
+license-files = [
+    { path = "LICENSE", hash = 0xd9300aad },
+]
+skip-files = [
+    "docs/api/static.files/COPYRIGHT-00000000b04765ec.txt",
+    "docs/api/static.files/FiraSans-LICENSE-000000004a115331.txt",
+    "docs/api/static.files/LICENSE-APACHE-00000000be5b60d4.txt",
+    "docs/api/static.files/LICENSE-MIT-00000000cc9db09c.txt",
+    "docs/api/static.files/NanumBarunGothic-LICENSE-0000000042e1adda.txt",
+    "docs/api/static.files/SourceCodePro-LICENSE-0000000063ca2e38.txt",
+    "docs/api/static.files/SourceSerif4-LICENSE-00000000d7b83a85.md",
+]
+
+[clarify.cliparser]
+expression = "Apache-2.0"
+license-files = [
+    { path = "LICENSE", hash = 0xd9300aad },
+]
+skip-files = [
+    "docs/api/COPYRIGHT.txt",
+    "docs/api/FiraSans-LICENSE.txt",
+    "docs/api/LICENSE-APACHE.txt",
+    "docs/api/LICENSE-MIT.txt",
+    "docs/api/NanumBarunGothic-LICENSE.txt",
+    "docs/api/SourceCodePro-LICENSE.txt",
+    "docs/api/SourceSerif4-LICENSE.md",
+]
+
+[clarify.envmnt]
+expression = "Apache-2.0"
+license-files = [
+    { path = "LICENSE", hash = 0xd9300aad },
+]
+skip-files = [
+    "docs/api/COPYRIGHT.txt",
+    "docs/api/FiraSans-LICENSE.txt",
+    "docs/api/LICENSE-APACHE.txt",
+    "docs/api/LICENSE-MIT.txt",
+    "docs/api/NanumBarunGothic-LICENSE.txt",
+    "docs/api/SourceCodePro-LICENSE.txt",
+    "docs/api/SourceSerif4-LICENSE.md",
+]
+
+[clarify.fsio]
+expression = "Apache-2.0"
+license-files = [
+    { path = "LICENSE", hash = 0xd9300aad },
+]
+skip-files = [
+    "docs/api/COPYRIGHT.txt",
+    "docs/api/FiraSans-LICENSE.txt",
+    "docs/api/LICENSE-APACHE.txt",
+    "docs/api/LICENSE-MIT.txt",
+    "docs/api/NanumBarunGothic-LICENSE.txt",
+    "docs/api/SourceCodePro-LICENSE.txt",
+    "docs/api/SourceSerif4-LICENSE.md",
+]
+
+[clarify.git_info]
+expression = "Apache-2.0"
+license-files = [
+    { path = "LICENSE", hash = 0xd9300aad },
+]
+skip-files = [
+    "docs/api/COPYRIGHT.txt",
+    "docs/api/FiraSans-LICENSE.txt",
+    "docs/api/LICENSE-APACHE.txt",
+    "docs/api/LICENSE-MIT.txt",
+    "docs/api/NanumBarunGothic-LICENSE.txt",
+    "docs/api/SourceCodePro-LICENSE.txt",
+    "docs/api/SourceSerifPro-LICENSE.md",
+]
+
+[clarify.regex]
+expression = "MIT OR Apache-2.0"
+license-files = [
+    { path = "LICENSE-APACHE", hash = 0x24b54f4b },
+    { path = "LICENSE-MIT", hash = 0xb755395b },
+]
+skip-files = [
+    "src/testdata/LICENSE", # we aren't using the test data
+]
+
+[clarify.regex-syntax]
+expression = "(MIT OR Apache-2.0) AND Unicode-DFS-2016"
+license-files = [
+    { path = "LICENSE-APACHE", hash = 0x24b54f4b },
+    { path = "LICENSE-MIT", hash = 0xb755395b },
+    { path = "src/unicode_tables/LICENSE-UNICODE", hash = 0xa7f28b93 },
+]
+
+[clarify.run_script]
+expression = "Apache-2.0"
+license-files = [
+    { path = "LICENSE", hash = 0xd9300aad },
+]
+skip-files = [
+    "docs/api/static.files/COPYRIGHT-00000000b04765ec.txt",
+    "docs/api/static.files/FiraSans-LICENSE-000000004a115331.txt",
+    "docs/api/static.files/LICENSE-APACHE-00000000be5b60d4.txt",
+    "docs/api/static.files/LICENSE-MIT-00000000cc9db09c.txt",
+    "docs/api/static.files/NanumBarunGothic-LICENSE-0000000042e1adda.txt",
+    "docs/api/static.files/SourceCodePro-LICENSE-0000000063ca2e38.txt",
+    "docs/api/static.files/SourceSerif4-LICENSE-00000000d7b83a85.md",
+]
+
+[clarify.rust_info]
+expression = "Apache-2.0"
+license-files = [
+    { path = "LICENSE", hash = 0xd9300aad },
+]
+skip-files = [
+    "docs/api/COPYRIGHT.txt",
+    "docs/api/FiraSans-LICENSE.txt",
+    "docs/api/LICENSE-APACHE.txt",
+    "docs/api/LICENSE-MIT.txt",
+    "docs/api/NanumBarunGothic-LICENSE.txt",
+    "docs/api/noto-sans-kr-v13-korean-regular-LICENSE.txt",
+    "docs/api/SourceCodePro-LICENSE.txt",
+    "docs/api/SourceSerif4-LICENSE.md",
+]
+
+[clarify.shell2batch]
+expression = "Apache-2.0"
+license-files = [
+    { path = "LICENSE", hash = 0xd9300aad },
+]
+skip-files = [
+    "docs/api/COPYRIGHT.txt",
+    "docs/api/FiraSans-LICENSE.txt",
+    "docs/api/LICENSE-APACHE.txt",
+    "docs/api/LICENSE-MIT.txt",
+    "docs/api/NanumBarunGothic-LICENSE.txt",
+    "docs/api/SourceCodePro-LICENSE.txt",
+    "docs/api/SourceSerif4-LICENSE.md",
+]
+
+[clarify.typenum]
+expression = "MIT OR Apache-2.0"
+license-files = [
+    { path = "LICENSE", hash = 0xa4618a29 },
+    { path = "LICENSE-MIT", hash = 0xb9f15462 },
+    { path = "LICENSE-APACHE", hash = 0x91d5a0a7 },
+]
+
+[clarify.unicode-ident]
+expression = "(MIT OR Apache-2.0) AND Unicode-DFS-2016"
+license-files = [
+    { path = "LICENSE-APACHE", hash = 0xb5518783 },
+    { path = "LICENSE-MIT", hash = 0x386ca1bc },
+    { path = "LICENSE-UNICODE", hash = 0x9698cbbe },
+]

--- a/configs/cargo-make/deny.toml
+++ b/configs/cargo-make/deny.toml
@@ -1,0 +1,77 @@
+[licenses]
+unlicensed = "deny"
+
+# Deny licenses unless they are specifically listed here
+copyleft = "deny"
+allow-osi-fsf-free = "neither"
+default = "deny"
+
+# We want really high confidence when inferring licenses from text
+confidence-threshold = 0.93
+
+allow = [
+    "Apache-2.0",
+    "BSD-3-Clause",
+    "BSL-1.0",
+    "ISC",
+    "MIT",
+    "OpenSSL",
+    "Unlicense",
+    "Zlib",
+]
+
+exceptions = [
+    { name = "attohttpc", allow = ["MPL-2.0"], version = "*" },
+    { name = "colored", allow = ["MPL-2.0"], version = "*" },
+    { name = "unicode-ident", allow = ["MIT", "Apache-2.0", "Unicode-DFS-2016"] },
+    { name = "webpki-roots", allow = ["MPL-2.0"], version = "*" },
+]
+
+[[licenses.clarify]]
+name = "ring"
+expression = "MIT AND ISC AND OpenSSL"
+license-files = [
+    { path = "LICENSE", hash = 0xbd0eed23 },
+]
+
+[[licenses.clarify]]
+name = "webpki"
+expression = "ISC"
+license-files = [
+    { path = "LICENSE", hash = 0x001c7e6c },
+]
+
+[[licenses.clarify]]
+name = "rustls-webpki"
+expression = "ISC"
+license-files = [
+    { path = "LICENSE", hash = 0x001c7e6c },
+]
+
+[bans]
+# Deny multiple versions or wildcard dependencies.
+multiple-versions = "deny"
+wildcards = "deny"
+
+skip = [
+    # num_cpus and atty use older versions of hermit-abi
+    { name = "hermit-abi" },
+
+    # Skip crates for unused platforms.
+    { name = "redox_syscall" },
+    { name = "wasi" },
+    { name = "windows-sys" },
+]
+
+skip-tree = [
+    # globset uses an older version of aho-corasick
+    { name = "globset", version = "0.4.10" },
+
+    # chrono uses an older version of time
+    { name = "chrono", version = "0.4.24" },
+]
+
+[sources]
+# Deny crates from unknown registries or git repositories.
+unknown-registry = "deny"
+unknown-git = "deny"

--- a/hashes/cargo-make
+++ b/hashes/cargo-make
@@ -1,0 +1,2 @@
+# https://github.com/sagiegurari/cargo-make/archive/0.36.8.tar.gz/#cargo-make-0.36.8.tar.gz
+SHA512 (cargo-make-0.36.8.tar.gz) = a9fdeabbd73956407b90bc764df648a5d709c7f96a5790c2c6dfa3e84f4b454b1163418788dcc582ef304da25953c5b3e348b1a36139c87e40adde4652b9799e


### PR DESCRIPTION
**Issue number:**
#108 


**Description of changes:**
Add `cargo-make` to the SDK.


**Testing done:**
Confirmed that `cargo make` runs.

```
[builder@c35a9c5ba2b3 ~]$ env | grep CARGO_MAKE
CARGO_MAKE_DISABLE_UPDATE_CHECK=1

[builder@c35a9c5ba2b3 ~]$ cargo make empty
[cargo-make] INFO - cargo make 0.36.8
[cargo-make] INFO - Build File: Makefile.toml
[cargo-make] INFO - Task: empty
[cargo-make] INFO - Profile: development
[cargo-make] INFO - Running Task: legacy-migration
[cargo-make] INFO - Build Done in 0.12 seconds.
```



**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
