### PR TITLE
Dockerfile: add xfsprogs to SDK

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -890,6 +890,7 @@ RUN \
     ShellCheck \
     squashfs-tools \
     veritysetup \
+    xfsprogs \
   && \
   dnf clean all
 


### PR DESCRIPTION
**Issue number:** https://github.com/bottlerocket-os/bottlerocket/issues/3036

**Description of changes:**
XFS can be advantageous in some situations. This adds support to the SDK for creating and managing XFS filesystems.

See Testing done for validation its working, more work will follow to tune these settings in the main repo, but this should be the only dependency strictly needed to enable XFS support in the SDK.

**Testing done:**
Built Bottlerocket with SDK while attempting to create an XFS data volume:
rpm2img
```
-  mkfs.ext4 -m 0 -d "${DATA_MOUNT}" "${BOTTLEROCKET_DATA}" "${size}"
-  echo "${UNLABELED}" | debugfs -w -f - "${BOTTLEROCKET_DATA}"
+  mkfs.xfs \
+   -b size=4096 -n size=16384 \
+   -m inobtcount=1,bigtime=1 \
+   -l internal,size=64m \
+   -d agcount=2,su=512k,sw=1,sectsize=4096 \
+   -f "${BOTTLEROCKET_DATA}"
```
and in `local.mount`
```
-Type=ext4
+Type=xfs
```
Finally, the image boots with XFS for `/local`!
```
bash-5.1# mount | grep local
/dev/nvme1n1p1 on /local type xfs (rw,nosuid,nodev,noatime,seclabel,attr2,inode64,logbufs=8,logbsize=32k,sunit=1024,swidth=1024,noquota)
```



**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
