### PR TITLE
integrate macros into the SDK

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -897,6 +897,19 @@ RUN \
 
 # =^..^=   =^..^=   =^..^=   =^..^=   =^..^=   =^..^=   =^..^=   =^..^=   =^..^=
 #
+# Generate macros for the target.
+
+FROM sdk as sdk-macros
+ARG ARCH
+
+COPY macros/* /tmp/
+
+WORKDIR /tmp
+RUN \
+  cat ${ARCH} shared rust cargo > /etc/rpm/macros.bottlerocket
+
+# =^..^=   =^..^=   =^..^=   =^..^=   =^..^=   =^..^=   =^..^=   =^..^=   =^..^=
+#
 # Collects all toolchain builds as single image layer
 FROM scratch as toolchain-golden
 COPY --from=toolchain-archive /toolchain /toolchain
@@ -993,6 +1006,11 @@ COPY --chown=0:0 --from=sdk-e2fsprogs \
 COPY --chown=0:0 --from=sdk-e2fsprogs \
   /home/builder/NOTICE \
   /usr/share/licenses/dir2fs/
+
+# "sdk-macros" has the rpm macros
+COPY --chown=0:0 --from=sdk-macros \
+  /etc/rpm/macros.bottlerocket \
+  /etc/rpm/macros.bottlerocket
 
 # Add Rust programs and libraries to the path.
 # Also add symlinks to help out with sysroot discovery.

--- a/macros/aarch64
+++ b/macros/aarch64
@@ -4,7 +4,7 @@
 %_cross_cpu_family arm
 %_cross_endian little
 
+%_cross_efi_arch aa64
 %_cross_grub_efi_format arm64-efi
-%_cross_grub_efi_image bootaa64.efi
 
 %_cross_go_arch arm64

--- a/macros/shared
+++ b/macros/shared
@@ -1,6 +1,6 @@
 %_cross_vendor bottlerocket
 %_cross_libc gnu
-%_cross_os %{_cross_vendor}-%{_cross_arch}-
+%_cross_os %{_cross_vendor}-
 %_cross_triple %{_cross_arch}-%{_cross_vendor}-linux
 %_cross_target %{_cross_triple}-%{_cross_libc}
 %dist %{nil}

--- a/macros/x86_64
+++ b/macros/x86_64
@@ -4,7 +4,7 @@
 %_cross_cpu_family x86
 %_cross_endian little
 
+%_cross_efi_arch x64
 %_cross_grub_efi_format x86_64-efi
-%_cross_grub_efi_image bootx64.efi
 
 %_cross_go_arch amd64


### PR DESCRIPTION
**Issue number:**
#108


**Description of changes:**
Add macros to the SDK under `/etc/rpm/macros.bottlerocket`.

Changing the SDK in the main repo will trigger a full rebuild of all packages, making it a good time to also drop the target architecture from the package name.

Reworking the GRUB macros will eliminate the need to change them in https://github.com/bottlerocket-os/bottlerocket/pull/3097, which will make `shim` the first stage bootloader.

**Testing done:**
Built variants in the main repo with the changes in https://github.com/bottlerocket-os/bottlerocket/pull/3213.


**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
