### PR TITLE
macros: prevent redefining _FORTIFY_SOURCE

### DIFF
--- a/macros/shared
+++ b/macros/shared
@@ -8,13 +8,15 @@
 %_cross_cflags %{shrink: \
   -O2 -g -pipe -Wall \
   -Werror=format-security -Werror=strict-aliasing \
-  -Wp,-D_FORTIFY_SOURCE=2 -Wp,-D_GLIBCXX_ASSERTIONS \
+  -Wp,-U_FORTIFY_SOURCE -Wp,-D_FORTIFY_SOURCE=2 \
+  -Wp,-D_GLIBCXX_ASSERTIONS \
   -fexceptions -fstack-clash-protection -fno-semantic-interposition \
   %{nil}}
 %_cross_c_args %{shrink: \
   '-O2', '-g', '-pipe', '-Wall', \
   '-Werror=format-security', '-Werror=strict-aliasing', \
-  '-Wp,-D_FORTIFY_SOURCE=2', '-Wp,-D_GLIBCXX_ASSERTIONS', \
+  '-Wp,-U_FORTIFY_SOURCE', '-Wp,-D_FORTIFY_SOURCE=2', \
+  '-Wp,-D_GLIBCXX_ASSERTIONS', \
   '-fexceptions', '-fstack-clash-protection', '-fno-semantic-interposition' \
   %{nil}}
 %_cross_cxxflags %_cross_cflags


### PR DESCRIPTION
<!--
Tips:
- Please read the CONTRIBUTING document to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->

**Issue number:** n/a



**Description of changes:**

macros: prevent redefining _FORTIFY_SOURCE

Ensure `_FORTIFY_SOURCE` is unset before setting it to the intended value. This prevents warnings or errors (if `-Werror` is used) in case a third-party package's build system also overrides `_FORTIFY_SOURCE`:

    <command-line>: error: "_FORTIFY_SOURCE" redefined [-Werror]
    <command-line>: note: this is the location of the previous definition

In this particular case, a package's build system needed to explicitly opt out of fortification for part of its code, adding the following to its `CFLAGS`:

    -U_FORTIFY_SOURCE -D_FORTIFY_SOURCE=0 -Wp,-U_FORTIFY_SOURCE -Wp,-D_FORTIFY_SOURCE=0

With the existing definition of `_FORTIFY_SOURCE=2` via Bottlerocket's RPM macros, this turns into a `gcc` invocation simplified to:

    -Wp,-D_FORTIFY_SOURCE=2 -U_FORTIFY_SOURCE -D_FORTIFY_SOURCE=0 -Wp,-U_FORTIFY_SOURCE -Wp,-D_FORTIFY_SOURCE=0

When the `gcc` compiler driver actually invokes the compiler, the arguments have been reordered: General macro definitions (`-D`, `-U`) come first, followed by options passed through to the preprocessor (`-Wp`). The reordering results in the following order of arguments to the compiler:

    -U_FORTIFY_SOURCE -D_FORTIFY_SOURCE=0 -D_FORTIFY_SOURCE=2 -U_FORTIFY_SOURCE -D_FORTIFY_SOURCE=0
                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

This now redefines `_FORTIFY_SOURCE` with a conflicting value. We can prevent that by always undefining a macro first, making undefine/define operations always show up pairwise in the resulting command line.


**Testing done:** For before and after the change, I cleaned the build directory, ran a full variant build (aws-k8s-1.24, aarch64), and ran `checksec` against all binaries in the built RPMs:

```
#!/usr/bin/env bash

for rpm_path in ./build/rpms/*.rpm; do
    rpm_name=${rpm_path##*/}
    extracted=$(mktemp -d)
    trap "rm -rf '${extracted}'" EXIT
    rpm2cpio "${rpm_path}" | cpio -D "${extracted}" -id --quiet
    (
        cd "${extracted}"
        find . -type f -executable -exec checksec --format=csv --file={} \;
    ) \
    | while read -r line; do echo "${rpm_name},${line}"; done
    rm -rf "${extracted}"
done
```

This showed no difference in before and after aside from the compressed kernel-devel squashfs differing in size by a few bytes. Specifically, there's been no difference in whether binaries have been compiled with fortification and the number of (un)checked functions used.


**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
