### PR TITLE
publish-sdk: derive region from repository URL

### DIFF
--- a/BUILDING.md
+++ b/BUILDING.md
@@ -85,5 +85,14 @@ To publish via the `publish-sdk` script, run:
 ./publish-sdk \
   --registry="aws_account_id.dkr.ecr.us-east-1.amazonaws.com" \
   --sdk-name="my-custom-bottlerocket" \
-  --version="v0.1.0"
+  --version="v0.1.0" \
+  --short-sha=0123abcd
 ```
+
+or:
+
+```shell
+make publish REGISTRY=aws_account_id.dkr.ecr.us-east-1.amazonaws.com SDK_NAME=my-custom-bottlerocket
+```
+
+to have the commit short SHA-1 hash and the SDK version derived from the state of the local Git repository.

--- a/publish-sdk
+++ b/publish-sdk
@@ -85,10 +85,11 @@ update_image() {
       --repository-name "${repo}" \
       --image-ids imageTag="${VERSION}" \
       --region "us-east-1"
-  elif [[ "${REGISTRY}" =~ ^[0-9]+\.dkr\.ecr\.[a-z0-9-]+\.amazonaws\.com$ ]]; then
+  elif [[ "${REGISTRY}" =~ ^[0-9]+\.dkr\.ecr\.([a-z0-9-]+)\.amazonaws\.com$ ]]; then
     aws ecr batch-delete-image \
       --repository-name "${repo}" \
-      --image-ids imageTag="${VERSION}"
+      --image-ids imageTag="${VERSION}" \
+      --region "${BASH_REMATCH[1]}"
   fi
 
   if ! docker manifest create "${remote_image}" \


### PR DESCRIPTION
**Issue number:** n/a

**Description of changes:** Fix the `publish-sdk` script to work without {a,the right} default region configured for the AWS CLI. Also update the docs on publishing the SDK while here. 


**Testing done:** Published a custom copy of the full set of SDK and toolchain for and from x86_64 and aarch64, i.e. with creation and update of the multi-arch manifests. This broke with AWS CLI bailing out before, but now results in the desired multi-arch images.


**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
