### PR TITLE
Update Go to 1.20.6

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -451,7 +451,7 @@ FROM sdk-libc as sdk-go
 
 ARG ARCH
 ARG TARGET="${ARCH}-bottlerocket-linux-gnu"
-ARG GOVER="1.20.5"
+ARG GOVER="1.20.6"
 
 USER root
 RUN dnf -y install golang

--- a/hashes/go
+++ b/hashes/go
@@ -1,2 +1,2 @@
-# https://go.dev/dl/go1.20.5.src.tar.gz
-SHA512 (go1.20.5.src.tar.gz) = 94cecb366cd9d9722b53e52ea3b0a5715a9e9dc21da0273dd3db9354557f71b9501b018125ef073dacc2e59125335f436cea1151cd8df0d60e2ad513f841905c
+# https://go.dev/dl/go1.20.6.src.tar.gz
+SHA512 (go1.20.6.src.tar.gz) = 509ade7c2a76bd46b26dda4522692ceef5023aae21461b866006341f98544e7ea755aee230a9fea789ed7afb1c49a693c34c8337892e308dfb051aef2b08c975


### PR DESCRIPTION
**Issue number:**

N/A

**Description of changes:**

This updates go to 1.20.6 to match the current version used upstream for building Kubernetes.

**Testing done:**

Built aws-k8s-1.24 using updated SDK. Created cluster and ran `sonobuoy run --mode=quick` - all tests passed. `kubectl get nodes` shows everything healthy.

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
