### PR TITLE
Update Rust to 1.71.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -349,7 +349,7 @@ RUN \
 ARG ARCH
 ARG HOST_ARCH
 ARG VENDOR="bottlerocket"
-ARG RUSTVER="1.70.0"
+ARG RUSTVER="1.71.0"
 
 USER builder
 WORKDIR /home/builder

--- a/hashes/rust
+++ b/hashes/rust
@@ -1,15 +1,15 @@
-# https://static.rust-lang.org/dist/rustc-1.70.0-src.tar.xz
-SHA512 (rustc-1.70.0-src.tar.xz) = 21b35185fdcc35a059ee5ef6dca2b68f5f1d199e97f425a571cfc318a852c36a57bccf68e7673b4cb7cd83128f30d0b3eb93009a978f3ba3909b7eee50d40631
-### See https://github.com/rust-lang/rust/blob/1.70.0/src/stage0.json for what to use below. ###
-# https://static.rust-lang.org/dist/2023-04-20/rust-std-1.69.0-x86_64-unknown-linux-gnu.tar.xz
-SHA512 (rust-std-1.69.0-x86_64-unknown-linux-gnu.tar.xz) = 3d4b25ba201064774ba0087489d71bdefea995f9f9233ea4231770d032e96a5e427494317358df0f8d88172e949112d14a9d906e603e80de9f21f3a43ec27bf4
-# https://static.rust-lang.org/dist/2023-04-20/rustc-1.69.0-x86_64-unknown-linux-gnu.tar.xz
-SHA512 (rustc-1.69.0-x86_64-unknown-linux-gnu.tar.xz) = 9bbf015f5c60448f3d9b1e2e6310bae58ecf5785fd35fa54b8acaa41b364fb765e5a16e8dfa7daab288798dcbd08d4be29fccd19f721388ebf8e3d0c90be48f3
-# https://static.rust-lang.org/dist/2023-04-20/cargo-1.69.0-x86_64-unknown-linux-gnu.tar.xz
-SHA512 (cargo-1.69.0-x86_64-unknown-linux-gnu.tar.xz) = 54ae60b3ca2777b365e520b7db30503d13ee887b9acdb31be26a91b6803b9af1ff81a70701e66102161fa76377e1c62a9b3613bde625a614ecfe0ceda9ef7249
-# https://static.rust-lang.org/dist/2023-04-20/rust-std-1.69.0-aarch64-unknown-linux-gnu.tar.xz
-SHA512 (rust-std-1.69.0-aarch64-unknown-linux-gnu.tar.xz) = 63298ff2d2e11313d9a65e66357346e4dfd06e1a437622558d3400ebed1c509037a767c13f75c3735e5c7feeb9937d0ffb63c25d984f9cc6f609decf4318bb0e
-# https://static.rust-lang.org/dist/2023-04-20/rustc-1.69.0-aarch64-unknown-linux-gnu.tar.xz
-SHA512 (rustc-1.69.0-aarch64-unknown-linux-gnu.tar.xz) = 5142c96d4f61969ce44df5bd7d044f6fbd194873a8349b9e85506eaab6c9244be298b7f2a7767d5a1bdccb8992f5829a499e83cecdc5232edfe94ed5574eeb9d
-# https://static.rust-lang.org/dist/2023-04-20/cargo-1.69.0-aarch64-unknown-linux-gnu.tar.xz
-SHA512 (cargo-1.69.0-aarch64-unknown-linux-gnu.tar.xz) = 743116a6947ac2946942713d7fb15bc964c83c6fb7d2cffdd1debc84d518c2c3ccc893a8a5d02794d750927bf8c1d4a2eb1bfabf540689110548d476db2e6e1e
+# https://static.rust-lang.org/dist/rustc-1.71.0-src.tar.xz
+SHA512 (rustc-1.71.0-src.tar.xz) = 2c93bafdd248563765a285add48ca77c1e4bad4d5431675ae6a5cdee4cfe7a41e6bcc880a489ca1069a307fd9a005f2d5f8e230dfc95b4a69152b4f9ca49ac44
+### See https://raw.githubusercontent.com/rust-lang/rust/1.71.0/src/stage0.json for what to use below. ###
+# https://static.rust-lang.org/dist/2023-06-01/rust-std-1.70.0-x86_64-unknown-linux-gnu.tar.xz
+SHA512 (rust-std-1.70.0-x86_64-unknown-linux-gnu.tar.xz) = 81ff6c73da530a5a0397ad777de2a33f7773eb58c38ba04410a3751a744c68631b0b02840170f5507c44cb4e9d2be882860e2ce663a406333ab6c57d73596956
+# https://static.rust-lang.org/dist/2023-06-01/rustc-1.70.0-x86_64-unknown-linux-gnu.tar.xz
+SHA512 (rustc-1.70.0-x86_64-unknown-linux-gnu.tar.xz) = 790ff039749654fa3ff2f481e5fe8012e3b5fe75d075c2210e49cd4093d3d3ddcdb6690e4d9b3012e7d6361a9629ab909723f1dee8171de1f87b6b418c99aaf9
+# https://static.rust-lang.org/dist/2023-06-01/cargo-1.70.0-x86_64-unknown-linux-gnu.tar.xz
+SHA512 (cargo-1.70.0-x86_64-unknown-linux-gnu.tar.xz) = 9e7a61ff6bb5a67a0ea4138259e0289c285ef7a5b3fbcad5ddcf780d2d5ec36000a5a3757b9a182b020abf646a25de3509789cf7df0fd4236231d5b92157c4e5
+# https://static.rust-lang.org/dist/2023-06-01/rust-std-1.70.0-aarch64-unknown-linux-gnu.tar.xz
+SHA512 (rust-std-1.70.0-aarch64-unknown-linux-gnu.tar.xz) = 8c472c23c4911c96ceea8c67c8a29aa7c99501df09ae078d6506860f5613e96039a08684ecb488b95a941550fceafec58726ea99139542cd0e27f6e126fa1b05
+# https://static.rust-lang.org/dist/2023-06-01/rustc-1.70.0-aarch64-unknown-linux-gnu.tar.xz
+SHA512 (rustc-1.70.0-aarch64-unknown-linux-gnu.tar.xz) = 786baefc4e4f4bda540bba9fa6fac668b8c166336a6494f1fa4057980f1ee95e34f4105409717cc61e034f98382cf8d5b59be6304d4b85de23651a2d15ed2ce2
+# https://static.rust-lang.org/dist/2023-06-01/cargo-1.70.0-aarch64-unknown-linux-gnu.tar.xz
+SHA512 (cargo-1.70.0-aarch64-unknown-linux-gnu.tar.xz) = 70e2078a77752e51ac8bc6affcb2f81be082791ff35ef03dd5480cad9da9654234c298d8f19b418b39984a3cf885d238fe0e16d3a7b9b71b006aebf925107475

--- a/tools/update-rust.sh
+++ b/tools/update-rust.sh
@@ -1,0 +1,93 @@
+#!/bin/bash
+
+set -e
+
+if [[ $# -lt 1 ]]; then
+    echo "Usage: $0 $RUST_VERSION"
+    echo
+    echo "Example: $0 1.71.0"
+    exit 2
+fi
+
+TOOLSDIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+ROOTDIR=$(realpath "${TOOLSDIR}/..")
+
+VERSION="${1}"
+OUTPUT="${ROOTDIR}/hashes/rust"
+PACKAGE_ROOT="https://static.rust-lang.org"
+METADATA_FILE="metadata.json"
+ARCHES=("x86_64" "aarch64")
+PACKAGES=("rust-std" "rustc" "cargo")
+
+function get_package_url {
+    local package="$1"
+    local arch="$2"
+
+    path=$(grep -e "${package}.*${arch}-unknown-linux-gnu.tar.xz" "${METADATA_FILE}" | cut -d '"' -f 2)
+
+    echo "${path}"
+}
+
+function add_package {
+    local package="$1"
+    local arch="$2"
+
+    # Lookup and pull down the package files
+    PKG_PATH=$(get_package_url "${package}" "${arch}")
+    PKG_FILE=$(echo "${PKG_PATH}" | cut -d '/' -f 3)
+    echo "Checking ${PACKAGE_ROOT}/${PKG_PATH}"
+    curl -s -O "${PACKAGE_ROOT}/${PKG_PATH}"
+    curl -s -O "${PACKAGE_ROOT}/${PKG_PATH}.asc"
+
+    # Verify file integrity
+    gpg --verify "${PKG_FILE}.asc" "${PKG_FILE}"
+
+    # Get the package source SHA
+    PKG_SHA=$(sha512sum "${PKG_FILE}" | cut -d ' ' -f 1)
+
+    # Clean up
+    rm "${PKG_FILE}" "${PKG_FILE}.asc"
+
+    # Write out details to the hash file
+    echo "# ${PACKAGE_ROOT}/${PKG_PATH}" >> "${OUTPUT}"
+    echo "SHA512 (${PKG_FILE}) = ${PKG_SHA}" >> "${OUTPUT}"
+}
+
+cd /tmp
+
+# Make sure the Rust project's public key is imported
+curl -s https://keybase.io/rust/pgp_keys.asc | gpg --import
+
+# Get the rustc source package
+RUSTC_PACKAGE="rustc-${VERSION}-src.tar.xz"
+RUSTC_URL="${PACKAGE_ROOT}/dist/${RUSTC_PACKAGE}"
+
+curl -s -O "${RUSTC_URL}"
+curl -s -O "${RUSTC_URL}.asc"
+gpg --verify "${RUSTC_PACKAGE}.asc" "${RUSTC_PACKAGE}"
+
+RUSTC_SHA=$(sha512sum "${RUSTC_PACKAGE}" | cut -d ' ' -f 1)
+rm "${RUSTC_PACKAGE}" "${RUSTC_PACKAGE}.asc"
+
+ARTIFACT_URL="https://raw.githubusercontent.com/rust-lang/rust/${VERSION}/src/stage0.json"
+curl -s -o "${METADATA_FILE}" "${ARTIFACT_URL}"
+
+# Add the root/header information
+echo "# ${RUSTC_URL}" > "${OUTPUT}"
+echo "SHA512 (${RUSTC_PACKAGE}) = ${RUSTC_SHA}" >> "${OUTPUT}"
+echo "### See ${ARTIFACT_URL} for what to use below. ###" >> "${OUTPUT}"
+
+# Get the details for each package
+for arch in "${ARCHES[@]}"; do
+    for package in "${PACKAGES[@]}"; do
+        add_package "${package}" "${arch}"
+    done
+done
+
+rm "${METADATA_FILE}"
+
+echo "================================================"
+echo "Rust toolchain updated to ${VERSION}"
+echo
+echo "Make sure to bump RUSTVER in Dockerfile to match"
+echo "================================================"


### PR DESCRIPTION
**Issue number:**

N/A

**Description of changes:**

This bumps the rust toolchain to the latest 1.71.1 release.

Also adds a helper script to make this process easier and a little more automated for future updates.

**Testing done:**

Built aws-k8s-1.24 using updated SDK. Created cluster and ran `sonobuoy run --mode=quick` - all tests passed. `kubectl get nodes` shows everything healthy.

Built aws-k8s-1.27 using updated SDK. Created cluster and ran `sonobuoy run --mode=quick` - all tests passed. `kubectl get nodes` shows everything healthy. Checked `systemctl status kubelet` and `journalctl -u kubelet`, no errors seen and everything appears happy.

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
