### PR TITLE
macros: add force_disable_rpath macro to centralize libtool hack

### DIFF
--- a/macros/shared
+++ b/macros/shared
@@ -244,3 +244,9 @@ CROSS_COMPILATION_CONF_EOF\
   %cross_generate_attribution
 
 %source_date_epoch_from_changelog 0
+
+# Forcefully prevent libtool from embedding an explicit rpath during linking,
+# for projects where the configure script does not implement --disable-rpath.
+%force_disable_rpath \
+  sed -i 's|^hardcode_libdir_flag_spec=.*|hardcode_libdir_flag_spec=""|g' libtool \
+  sed -i 's|^runpath_var=LD_RUN_PATH|runpath_var=DIE_RPATH_DIE|g' libtool


### PR DESCRIPTION
**Issue number:** n/a

**Description of changes:** Various third-party packages utilizing libtool don't provide an option in their `configure` script to disable embedding an rpath into ELF files during linking. The spec files of those packages make use of [a libtool hack](https://listman.redhat.com/archives/fedora-extras-list/2006-October/029255.html) that dates back to 2006. Move that into a shared macro so it can be easily reused instead of duplicated.

Currently, there's 12 packages reusing the hack verbatim. Example: [`wicked.spec`](https://github.com/bottlerocket-os/bottlerocket/blob/ef2fe106efd55728596c0d89cbfce53a58f79e61/packages/wicked/wicked.spec#L87)

**Testing done:** Built the SDK and used the resulting image for building a Bottlerocket variant (only showing the new definition doesn't break existing builds, will provide separate testing for switching over to use the macro in the mono repo).

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
