### PR TITLE
Revert "Update Go to 1.20.6"

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -451,7 +451,7 @@ FROM sdk-libc as sdk-go
 
 ARG ARCH
 ARG TARGET="${ARCH}-bottlerocket-linux-gnu"
-ARG GOVER="1.20.6"
+ARG GOVER="1.20.5"
 
 USER root
 RUN dnf -y install golang

--- a/hashes/go
+++ b/hashes/go
@@ -1,2 +1,2 @@
-# https://go.dev/dl/go1.20.6.src.tar.gz
-SHA512 (go1.20.6.src.tar.gz) = 509ade7c2a76bd46b26dda4522692ceef5023aae21461b866006341f98544e7ea755aee230a9fea789ed7afb1c49a693c34c8337892e308dfb051aef2b08c975
+# https://go.dev/dl/go1.20.5.src.tar.gz
+SHA512 (go1.20.5.src.tar.gz) = 94cecb366cd9d9722b53e52ea3b0a5715a9e9dc21da0273dd3db9354557f71b9501b018125ef073dacc2e59125335f436cea1151cd8df0d60e2ad513f841905c


### PR DESCRIPTION
**Issue number:**

Related: https://github.com/moby/moby/issues/45935

**Description of changes:**

This reverts the bump to Go 1.20.6 until the Moby issue can be investigated. It's possible there are no problems, but reading the bug report, there's a pretty fundamental change in this patch release. Original testing was a quick validation, since nothing was expected with a patch release, but this will require more complete testing with `k8s` and `ecs` variants to make sure there are no surprises.

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
