### PR TITLE
license-scan: allow clarification version reqs

### DIFF
--- a/license-scan/Cargo.lock
+++ b/license-scan/Cargo.lock
@@ -63,6 +63,8 @@ dependencies = [
  "cargo_metadata",
  "ignore",
  "lazy_static",
+ "maplit",
+ "semver 1.0.18",
  "serde",
  "spdx",
  "structopt",
@@ -93,7 +95,7 @@ version = "0.11.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a3a567c24b86754d629addc2db89e340ac9398d07b5875efcff837e3878e17ec"
 dependencies = [
- "semver",
+ "semver 0.10.0",
  "serde",
  "serde_json",
 ]
@@ -292,6 +294,12 @@ checksum = "abb12e687cfb44aa40f41fc3978ef76448f9b6038cad6aef4259d3c095a2382e"
 dependencies = [
  "cfg-if",
 ]
+
+[[package]]
+name = "maplit"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3e2e65a1a2e43cfcb47a895c4c8b10d1f4a61097f9f254f183aee60cad9c651d"
 
 [[package]]
 name = "memchr"
@@ -521,6 +529,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "394cec28fa623e00903caf7ba4fa6fb9a0e260280bb8cdbbba029611108a0190"
 dependencies = [
  "semver-parser",
+ "serde",
+]
+
+[[package]]
+name = "semver"
+version = "1.0.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b0293b4b29daaf487284529cc2f5675b8e57c61f70167ba415a463651fd6a918"
+dependencies = [
  "serde",
 ]
 

--- a/license-scan/Cargo.toml
+++ b/license-scan/Cargo.toml
@@ -12,9 +12,13 @@ askalono = "0.4"
 cargo_metadata = "0.11"
 ignore = "0.4"
 lazy_static = "1"
+semver = { version = "1", features = ["serde"] }
 serde = { version = "1", features = ["derive"] }
 spdx = "0.3"
 structopt = { version = "0.3", default-features = false }
 toml = "0.5"
 twox-hash = "1"
 walkdir = "2"
+
+[dev-dependencies]
+maplit = "1"

--- a/license-scan/testdata/clarifications_sample.toml
+++ b/license-scan/testdata/clarifications_sample.toml
@@ -1,0 +1,47 @@
+# Each sample MUST have a different license expression to disambiguate match results.
+[clarify.singlepackage]
+expression = "Apache-2.0"
+license-files = [
+    { path = "LICENSE", hash = 0x00000000 },
+    { path = "NOTICE", hash = 0x00000000 },
+]
+
+[clarify.singleversioned]
+version = "^1.0"
+expression = "MIT"
+license-files = [
+    { path = "LICENSE", hash = 0x00000000 },
+    { path = "NOTICE", hash = 0x00000000 },
+]
+
+[[clarify.multipackage]]
+version = "^1.1"
+expression = "Apache-2.0 OR MIT"
+license-files = [
+    { path = "LICENSE", hash = 0x00000001 },
+    { path = "NOTICE", hash = 0x00000001 },
+]
+
+[[clarify.multipackage]]
+version = "=2"
+expression = "Apache-2.0 OR BSD-3-Clause"
+license-files = [
+    { path = "LICENSE", hash = 0x00000002 },
+    { path = "NOTICE", hash = 0x00000002 },
+]
+
+[[clarify.overlapping]]
+version = "^1.3"
+expression = "BSD-3-Clause"
+license-files = [
+    { path = "LICENSE", hash = 0x00000000 },
+    { path = "NOTICE", hash = 0x00000000 },
+]
+
+[[clarify.overlapping]]
+version = "^1.1"
+expression = "BSD-3-Clause AND Apache-2.0"
+license-files = [
+    { path = "LICENSE", hash = 0x00000000 },
+    { path = "NOTICE", hash = 0x00000000 },
+]


### PR DESCRIPTION
**Description of changes:**
Closes #98 

```
license-scan: allow clarification version reqs

Clarifications can now optionally provide semver version specifiers.
See https://docs.rs/semver/latest/semver/enum.Op.html for more details
on allowed specifiers.
```

While trying to [update the `regex` crate](https://github.com/bottlerocket-os/bottlerocket-update-operator/pull/482) for the [bottlerocket-update-operator](https://github.com/bottlerocket-os/bottlerocket-update-operator), two major versions of `regex-automata` are pulled in due to [`matchers` being on an older version](https://github.com/hawkw/matchers/issues/3).

Unfortunately, `clarify.toml`'s existing clarification for `regex-automata-0.1` clashes with the new licensing for `regex-automata-0.3`. This adds the ability to clarify both versions.

**Limitations**
This currently assumes that the versions will follow semver; however, this implementation does not close the door to other version comparisons. If need be, we can replace `VersionReq` with an enum that also supports fallback to something like [RPM version comparison](https://fedoraproject.org/wiki/Archive:Tools/RPM/VersionComparison)


**Testing done:**
* Provided unit tests pass

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
