### PR TITLE
Update Go to 1.20.7

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -451,7 +451,7 @@ FROM sdk-libc as sdk-go
 
 ARG ARCH
 ARG TARGET="${ARCH}-bottlerocket-linux-gnu"
-ARG GOVER="1.20.6"
+ARG GOVER="1.20.7"
 
 USER root
 RUN dnf -y install golang

--- a/hashes/go
+++ b/hashes/go
@@ -1,2 +1,2 @@
-# https://go.dev/dl/go1.20.6.src.tar.gz
-SHA512 (go1.20.6.src.tar.gz) = 509ade7c2a76bd46b26dda4522692ceef5023aae21461b866006341f98544e7ea755aee230a9fea789ed7afb1c49a693c34c8337892e308dfb051aef2b08c975
+# https://go.dev/dl/go1.20.7.src.tar.gz
+SHA512 (go1.20.7.src.tar.gz) = c3dae709d0db8ab32a68bda2d260ffe86ee77c703bdbf34eefd0e1f745dd0aa04e3d17833877e7f06aa066686da501a85361591e510a341affc0244dde2b9946


### PR DESCRIPTION
**Issue number:**

N/A

**Description of changes:**

This updates go to 1.20.7 to match the current version used upstream for building Kubernetes.

https://github.com/kubernetes/kubernetes/blob/cb56c4c627fc627b2eb1ba69a435cc3f205f7363/.go-version

**Testing done:**

Deployed two node `aws-k8s-1.27-aarch64` cluster. Ran `sonobuoy run --mode=quick` to verify basic functionality:

```
13:43:49             e2e                                         global   complete   passed   Passed:  1, Failed:  0, Remaining:  0
13:43:49    systemd-logs   ip-192-168-51-149.us-east-2.compute.internal   complete   passed
```

Looked at `journalctl` and `systemctl status` output to spot check for any errors, none found.

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
