### PR TITLE
license-scan: allow multiple semver crates

### DIFF
--- a/license-scan/deny.toml
+++ b/license-scan/deny.toml
@@ -26,6 +26,10 @@ exceptions = [
 multiple-versions = "deny"
 wildcards = "deny"
 
+skip = [
+    { name = "semver", version = "0.10.0" },
+]
+
 [sources]
 # Deny crates from unknown registries or git repositories.
 unknown-registry = "deny"


### PR DESCRIPTION
**Issue number:**

N/A

**Description of changes:**

With the recent change to handle license clarification with multiple crates, we introduced a second, newer semver dependency. This is fine and expected, but now causes an issue when building the SDK. During the SDK build, when `cargo-deny` is run against the license-scan tool, it now complains about having these multiple versions.

This adds a `skip` setting to the `deny.toml` file to instruct `cargo-deny` to ignore the older version until we are able to move to a single crate.

**Testing done:**

Before:

```
$ cd license-scan
$ cargo-deny --all-features check --disable-fetch licenses bans sources
error[B004]: found 2 duplicate entries for crate 'semver'
   ┌─ /home/stmcg/src/bottlerocket-os/bottlerocket-sdk/license-scan/Cargo.lock:58:1
   │  
58 │ ╭ semver 0.10.0 registry+https://github.com/rust-lang/crates.io-index
59 │ │ semver 1.0.18 registry+https://github.com/rust-lang/crates.io-index
   │ ╰───────────────────────────────────────────────────────────────────^ lock entries
   │  
   = semver v0.10.0
     └── cargo_metadata v0.11.4
         └── bottlerocket-license-scan v0.1.0
   = semver v1.0.18
     └── bottlerocket-license-scan v0.1.0

bans FAILED, licenses ok, sources ok
```

After:

```
$ cd license-scan
$ cargo-deny --all-features check --disable-fetch licenses bans sources
bans ok, licenses ok, sources ok
```

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
