### PR TITLE
license-scan: Update cargo-metadata

### DIFF
--- a/license-scan/Cargo.lock
+++ b/license-scan/Cargo.lock
@@ -64,7 +64,7 @@ dependencies = [
  "ignore",
  "lazy_static",
  "maplit",
- "semver 1.0.18",
+ "semver",
  "serde",
  "spdx",
  "structopt",
@@ -90,12 +90,32 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "14c189c53d098945499cdfa7ecc63567cf3886b3332b312a5b4585d8d3a6a610"
 
 [[package]]
-name = "cargo_metadata"
-version = "0.11.4"
+name = "camino"
+version = "1.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a3a567c24b86754d629addc2db89e340ac9398d07b5875efcff837e3878e17ec"
+checksum = "c59e92b5a388f549b863a7bea62612c09f24c8393560709a54558a9abdfb3b9c"
 dependencies = [
- "semver 0.10.0",
+ "serde",
+]
+
+[[package]]
+name = "cargo-platform"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2cfa25e60aea747ec7e1124f238816749faa93759c6ff5b31f1ccdda137f4479"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "cargo_metadata"
+version = "0.14.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4acbb09d9ee8e23699b9634375c72795d095bf268439da88562cf9b501f181fa"
+dependencies = [
+ "camino",
+ "cargo-platform",
+ "semver",
  "serde",
  "serde_json",
 ]
@@ -524,28 +544,12 @@ checksum = "d29ab0c6d3fc0ee92fe66e2d99f700eab17a8d57d1c1d3b748380fb20baa78cd"
 
 [[package]]
 name = "semver"
-version = "0.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "394cec28fa623e00903caf7ba4fa6fb9a0e260280bb8cdbbba029611108a0190"
-dependencies = [
- "semver-parser",
- "serde",
-]
-
-[[package]]
-name = "semver"
 version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b0293b4b29daaf487284529cc2f5675b8e57c61f70167ba415a463651fd6a918"
 dependencies = [
  "serde",
 ]
-
-[[package]]
-name = "semver-parser"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "388a1df253eca08550bef6c72392cfe7c30914bf41df5269b68cbd6ff8f570a3"
 
 [[package]]
 name = "serde"

--- a/license-scan/Cargo.toml
+++ b/license-scan/Cargo.toml
@@ -9,7 +9,7 @@ publish = false
 [dependencies]
 anyhow = "1"
 askalono = "0.4"
-cargo_metadata = "0.11"
+cargo_metadata = "0.14"
 ignore = "0.4"
 lazy_static = "1"
 semver = { version = "1", features = ["serde"] }

--- a/license-scan/src/main.rs
+++ b/license-scan/src/main.rs
@@ -121,6 +121,7 @@ fn main() -> Result<()> {
                     Some(&package.version.to_string().parse()?),
                     package
                         .manifest_path
+                        .into_std_path_buf()
                         .parent()
                         .expect("expected a path to Cargo.toml to have a parent"),
                     &opt.out_dir


### PR DESCRIPTION


<!--
Tips:
- Please read the CONTRIBUTING document to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->

**Issue number:**

N/A

**Description of changes:**

With the recent change to handle license clarification with multiple crates, we introduced a second, newer semver dependency. This is fine and expected, but now causes an issue when building the SDK. During the SDK build, when `cargo-deny` is run against the license-scan tool, it now complains about having these multiple versions.

This bumps the version of cargo-metadata used so we don't pull in two different semver versions.

**Testing done:**

Before:

```
$ cd license-scan
$ cargo-deny --all-features check --disable-fetch licenses bans sources
error[B004]: found 2 duplicate entries for crate 'semver'
   ┌─ /home/stmcg/src/bottlerocket-os/bottlerocket-sdk/license-scan/Cargo.lock:58:1
   │  
58 │ ╭ semver 0.10.0 registry+https://github.com/rust-lang/crates.io-index
59 │ │ semver 1.0.18 registry+https://github.com/rust-lang/crates.io-index
   │ ╰───────────────────────────────────────────────────────────────────^ lock entries
   │  
   = semver v0.10.0
     └── cargo_metadata v0.11.4
         └── bottlerocket-license-scan v0.1.0
   = semver v1.0.18
     └── bottlerocket-license-scan v0.1.0

bans FAILED, licenses ok, sources ok
```

After:

```
$ cd license-scan
$ cargo-deny --all-features check --disable-fetch licenses bans sources
bans ok, licenses ok, sources ok
```

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
