### PR TITLE
Add helper script to update go version

### DIFF
--- a/tools/update-go.sh
+++ b/tools/update-go.sh
@@ -1,0 +1,52 @@
+#!/usr/bin/env bash
+
+set -e
+
+if [[ $# -lt 1 ]]; then
+    echo "Usage: $0 $GO_VERSION"
+    echo
+    echo "Example: $0 1.21.1"
+    exit 2
+fi
+
+TOOLSDIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+ROOTDIR=$(realpath "${TOOLSDIR}/..")
+
+VERSION="${1}"
+OUTPUT="${ROOTDIR}/hashes/go"
+PACKAGE_ROOT="https://go.dev/dl"
+
+# Get the go source package
+# e.g. https://go.dev/dl/go1.21.1.src.tar.gz
+GO_SRC_PACKAGE="go${VERSION}.src.tar.gz"
+GO_SRC_URL="${PACKAGE_ROOT}/${GO_SRC_PACKAGE}"
+
+curl -s -L -O -C - "${GO_SRC_URL}"
+
+# SHA256 is only used to validate the package with the published checksum
+GO_256_SHA=$(sha256sum "${GO_SRC_PACKAGE}" | cut -d ' ' -f 1)
+
+# The Go downloads are not signed, and there is not an easy checksum file to
+# fetch to validate the download. This is a little fragile (will need to update
+# if they change the download page structure) but it at least gives some level
+# of validation that we have a good download.
+PUBLISHED_MATCH=$(curl -s https://go.dev/dl/ | grep -B5 "${GO_256_SHA}" | grep "${GO_SRC_PACKAGE}")
+if [[ -z "${PUBLISHED_MATCH}" ]]; then
+    echo "Unable to verify source package checksum!!!"
+    echo
+    echo "Check ${GO_SRC_PACKAGE} contents compared to ${PACKAGE_ROOT}"
+    echo "Local checksum: ${GO_256_SHA}"
+    exit 2
+fi
+
+GO_512_SHA=$(sha512sum "${GO_SRC_PACKAGE}" | cut -d ' ' -f 1)
+
+# Add the root/header information
+echo "# ${GO_SRC_URL}" > "${OUTPUT}"
+echo "SHA512 (${GO_SRC_PACKAGE}) = ${GO_512_SHA}" >> "${OUTPUT}"
+
+echo "================================================"
+echo "go toolchain updated to ${VERSION}"
+echo
+echo "Make sure to bump GOVER in Dockerfile to match"
+echo "================================================"


### PR DESCRIPTION
**Issue number:**

N/A

**Description of changes:**

Similar to the recently added update-rust script, this takes the version of Go desired and fetches the file to verify and calculate the hash. It then updates the `hashes/go` file to use the requested version.

**Testing done:**

Used script to pull various releases and verified it works as expected.

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
