### PR TITLE
Restore copyright notice for rust and cargo macros

### DIFF
--- a/COPYRIGHT
+++ b/COPYRIGHT
@@ -11,3 +11,9 @@ control history.
 Bottlerocket operating system images include packages written by third parties, which may carry
 their own copyright notices and license terms. These are available in /usr/share/licenses on the
 operating system images.
+
+=^..^=   =^..^=   =^..^=   =^..^=   =^..^=   =^..^=   =^..^=   =^..^=   =^..^=   =^..^=   =^..^=
+
+macros/rust and macros/cargo (used during build) are derived from the Fedora Rust SIG's rust2rpm.
+https://pagure.io/fedora-rust/rust2rpm
+Copyright (c) 2017 Igor Gnatenko. Licensed under the MIT License.


### PR DESCRIPTION
**Issue number:**

#135

**Description of changes:**

This notice is moving from the `COPYRIGHT` in [bottlerocket-os/bottlerocket](https://github.com/bottlerocket-os/bottlerocket) to [bottlerocket-os/bottlerocket-sdk](https://github.com/bottlerocket-os/bottlerocket-sdk).

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
