### PR TITLE
add protobuf-compiler and protobuf-devel

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -900,6 +900,8 @@ RUN \
     openssl-pkcs11 \
     pesign \
     policycoreutils \
+    protobuf-compiler \
+    protobuf-devel \
     python3-jinja2 \
     python3-virt-firmware \
     qemu-img \


### PR DESCRIPTION
**Issue number:** n/a



**Description of changes:** Add the Protocol Buffers compiler to the SDK for packages utilizing it during build.



**Testing done:** Built and published the SDK with the change on the full architecture matrix. Used it to successfully built a metal-dev Bottlerocket image.



**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
