### PR TITLE
remove maven and JDK

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -887,14 +887,9 @@ RUN \
     glib2-devel \
     gnupg-pkcs11-scd \
     gnutls-utils \
-    java-11-openjdk-devel \
     kpartx \
     libcap-devel \
     lz4 \
-    maven-clean-plugin \
-    maven-local \
-    maven-openjdk11 \
-    maven-shade-plugin \
     mtools \
     nss-tools \
     openssl-pkcs11 \


### PR DESCRIPTION
**Issue number:**
Fixes #132


**Description of changes:**
These are no longer needed for building the log4j2 hotpatch. Remove them to cut down the image size.


**Testing done:**
Built a Bottlerocket image with a custom SDK build that included this change. 


**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
