### PR TITLE
tools: automate GOVER and RUSTVER edits

### DIFF
--- a/tools/update-go.sh
+++ b/tools/update-go.sh
@@ -45,8 +45,9 @@ GO_512_SHA=$(sha512sum "${GO_SRC_PACKAGE}" | cut -d ' ' -f 1)
 echo "# ${GO_SRC_URL}" > "${OUTPUT}"
 echo "SHA512 (${GO_SRC_PACKAGE}) = ${GO_512_SHA}" >> "${OUTPUT}"
 
+DOCKERFILE="${ROOTDIR}/Dockerfile"
+sed -i -e "s,^ARG GOVER=.*,ARG GOVER=\"${VERSION}\",g" "${DOCKERFILE}"
+
 echo "================================================"
 echo "go toolchain updated to ${VERSION}"
-echo
-echo "Make sure to bump GOVER in Dockerfile to match"
 echo "================================================"

--- a/tools/update-rust.sh
+++ b/tools/update-rust.sh
@@ -84,8 +84,9 @@ done
 
 rm "${METADATA_FILE}"
 
+DOCKERFILE="${ROOTDIR}/Dockerfile"
+sed -i -e "s,^ARG RUSTVER=.*,ARG RUSTVER=\"${VERSION}\",g" "${DOCKERFILE}"
+
 echo "================================================"
 echo "Rust toolchain updated to ${VERSION}"
-echo
-echo "Make sure to bump RUSTVER in Dockerfile to match"
 echo "================================================"


### PR DESCRIPTION
**Issue number:**
N/A


**Description of changes:**
Automate GOVER and RUSTVER edits.


**Testing done:**
Ran `update-go.sh` and `update-rust.sh` and verified that `GOVER` and `RUSTVER` were replaced in `Dockerfile`.


**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
