### PR TITLE
go: Update to Go 1.21.3

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -451,7 +451,7 @@ FROM sdk-libc as sdk-go
 
 ARG ARCH
 ARG TARGET="${ARCH}-bottlerocket-linux-gnu"
-ARG GOVER="1.20.10"
+ARG GOVER="1.21.3"
 
 USER root
 RUN dnf -y install golang

--- a/hashes/go
+++ b/hashes/go
@@ -1,2 +1,2 @@
-# https://go.dev/dl/go1.20.10.src.tar.gz
-SHA512 (go1.20.10.src.tar.gz) = 1c6304abb8a7847cedb634380d43fcbf2b206f0e6af99e915b4735b4c5f9dfc08a01db6d41edaed91a2a8140fcd886343d39465bd6fb53bd37be0a7f41dc6525
+# https://go.dev/dl/go1.21.3.src.tar.gz
+SHA512 (go1.21.3.src.tar.gz) = c98d31b9c477c0ac4b6f6933adefb40fdce5cdbb171e5236e3b694fec9e5b04695487af734259eab304dd42e86341240621a781f54b60c719627fd7b5efe4742


### PR DESCRIPTION
**Issue number:**

N/A

**Description of changes:**

This matches the current go release used by kubernetes/kubernetes and is the current latest Go release.

**Testing done:**

~Ran `make` and verified no errors building the SDK.~

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
