### PR TITLE
sdk-go-fips: add FIPS-enabled go toolchain to SDK

### DIFF
--- a/hashes/aws-lc
+++ b/hashes/aws-lc
@@ -1,0 +1,2 @@
+# https://github.com/aws/aws-lc/archive/refs/tags/AWS-LC-FIPS-2.0.2.tar.gz
+SHA512 (AWS-LC-FIPS-2.0.2.tar.gz) = 108bfc5c883c8ac590274918b10863f20f28a4a06ef4dc44d3b2e147c0dca0d6d304459cc0e19c2b76925091571f47e5d045c0114f9f7b2cac332e53e73995b3

--- a/patches/go-fips/0001-Make-boringcypto-build-compatible-with-aws-lc-librar.patch
+++ b/patches/go-fips/0001-Make-boringcypto-build-compatible-with-aws-lc-librar.patch
@@ -1,0 +1,73 @@
+From fce848295f8ce4fe7352c83d68d186ba077097f3 Mon Sep 17 00:00:00 2001
+From: Erikson Tung <etung@amazon.com>
+Date: Sat, 18 Nov 2023 00:46:13 +0000
+Subject: [PATCH] Make boringcypto build compatible with aws-lc library
+
+Signed-off-by: Dusan Kostic <dkostic@amazon.com>
+Signed-off-by: Erikson Tung <etung@amazon.com>
+---
+ src/crypto/internal/boring/build-boring.sh  | 2 +-
+ src/crypto/internal/boring/goboringcrypto.h | 6 +++---
+ src/crypto/internal/boring/rsa.go           | 2 +-
+ 3 files changed, 5 insertions(+), 5 deletions(-)
+
+diff --git a/src/crypto/internal/boring/build-boring.sh b/src/crypto/internal/boring/build-boring.sh
+index db49852a63..765654af4d 100755
+--- a/src/crypto/internal/boring/build-boring.sh
++++ b/src/crypto/internal/boring/build-boring.sh
+@@ -35,7 +35,7 @@ printf "set(CMAKE_C_COMPILER \"clang\")\nset(CMAKE_CXX_COMPILER \"clang++\")\n"
+ cd boringssl
+ mkdir build && cd build && cmake -GNinja -DCMAKE_TOOLCHAIN_FILE=${HOME}/toolchain -DFIPS=1 -DCMAKE_BUILD_TYPE=Release ..
+ ninja
+-./crypto/crypto_test
++#./crypto/crypto_test
+ cd ../..
+ 
+ if [ "$(./boringssl/build/tool/bssl isfips)" != 1 ]; then
+diff --git a/src/crypto/internal/boring/goboringcrypto.h b/src/crypto/internal/boring/goboringcrypto.h
+index 2b11049728..5ac467c972 100644
+--- a/src/crypto/internal/boring/goboringcrypto.h
++++ b/src/crypto/internal/boring/goboringcrypto.h
+@@ -84,7 +84,7 @@ int _goboringcrypto_EVP_MD_type(const GO_EVP_MD*);
+ size_t _goboringcrypto_EVP_MD_size(const GO_EVP_MD*);
+ 
+ // #include <openssl/hmac.h>
+-typedef struct GO_HMAC_CTX { char data[104]; } GO_HMAC_CTX;
++typedef struct GO_HMAC_CTX { char data[672]; } GO_HMAC_CTX;
+ void _goboringcrypto_HMAC_CTX_init(GO_HMAC_CTX*);
+ void _goboringcrypto_HMAC_CTX_cleanup(GO_HMAC_CTX*);
+ int _goboringcrypto_HMAC_Init(GO_HMAC_CTX*, const void*, int, const GO_EVP_MD*);
+@@ -199,7 +199,7 @@ int _goboringcrypto_ECDSA_verify(int, const uint8_t*, size_t, const uint8_t*, si
+ // #include <openssl/rsa.h>
+ 
+ // Note: order of struct fields here is unchecked.
+-typedef struct GO_RSA { void *meth; GO_BIGNUM *n, *e, *d, *p, *q, *dmp1, *dmq1, *iqmp; char data[168]; } GO_RSA;
++typedef struct GO_RSA { void *meth; GO_BIGNUM *n, *e, *d, *p, *q, *dmp1, *dmq1, *iqmp; char data[176]; } GO_RSA;
+ /*unchecked (opaque)*/ typedef struct GO_BN_GENCB { char data[1]; } GO_BN_GENCB;
+ GO_RSA* _goboringcrypto_RSA_new(void);
+ void _goboringcrypto_RSA_free(GO_RSA*);
+@@ -216,7 +216,7 @@ enum {
+ };
+ int _goboringcrypto_RSA_encrypt(GO_RSA*, size_t *out_len, uint8_t *out, size_t max_out, const uint8_t *in, size_t in_len, int padding);
+ int _goboringcrypto_RSA_decrypt(GO_RSA*, size_t *out_len, uint8_t *out, size_t max_out, const uint8_t *in, size_t in_len, int padding);
+-int _goboringcrypto_RSA_sign(int hash_nid, const uint8_t* in, unsigned int in_len, uint8_t *out, unsigned int *out_len, GO_RSA*);
++int _goboringcrypto_RSA_sign(int hash_nid, const uint8_t* in, unsigned long in_len, uint8_t *out, unsigned int *out_len, GO_RSA*);
+ int _goboringcrypto_RSA_sign_pss_mgf1(GO_RSA*, size_t *out_len, uint8_t *out, size_t max_out, const uint8_t *in, size_t in_len, const GO_EVP_MD *md, const GO_EVP_MD *mgf1_md, int salt_len);
+ int _goboringcrypto_RSA_sign_raw(GO_RSA*, size_t *out_len, uint8_t *out, size_t max_out, const uint8_t *in, size_t in_len, int padding);
+ int _goboringcrypto_RSA_verify(int hash_nid, const uint8_t *msg, size_t msg_len, const uint8_t *sig, size_t sig_len, GO_RSA*);
+diff --git a/src/crypto/internal/boring/rsa.go b/src/crypto/internal/boring/rsa.go
+index fa693ea319..3057e93bcf 100644
+--- a/src/crypto/internal/boring/rsa.go
++++ b/src/crypto/internal/boring/rsa.go
+@@ -340,7 +340,7 @@ func SignRSAPKCS1v15(priv *PrivateKeyRSA, h crypto.Hash, hashed []byte) ([]byte,
+ 	var outLen C.uint
+ 	if priv.withKey(func(key *C.GO_RSA) C.int {
+ 		out = make([]byte, C._goboringcrypto_RSA_size(key))
+-		return C._goboringcrypto_RSA_sign(nid, base(hashed), C.uint(len(hashed)),
++		return C._goboringcrypto_RSA_sign(nid, base(hashed), C.ulong(len(hashed)),
+ 			base(out), &outLen, key)
+ 	}) == 0 {
+ 		return nil, fail("RSA_sign")
+-- 
+2.41.0
+


### PR DESCRIPTION
<!--
Tips:
- Please read the CONTRIBUTING document to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->

**Issue number:**
N/A


**Description of changes:**
```bash
    go-fips: add FIPS-enabled go toolchain
    
    go-fips is built with boringcrypto crypto modules built with aws-lc FIPS
    crypto library.
```


**Testing done:**
SDK builds fine. The go toolchain tests all pass. The `go-fips` toolchain works as expected:
```bash
[builder@bfccc19af733 ~]$ go-fips version
go version go1.21.4 X:boringcrypto linux/arm64
[builder@bfccc19af733 ~]$ cat >is_awslc_used.go <<'EOF'  
package main  
import "fmt"  
import "crypto/boring"  
func main() {  
fmt.Printf("%v\n", boring.Enabled())  
}  
EOF
[builder@bfccc19af733 ~]$ go-fips run ./is_awslc_used.go 
true
```

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
