### PR TITLE
Replace Fedora's `awscli` with upstream binaries

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -876,7 +876,6 @@ FROM sdk as sdk-plus
 USER root
 RUN \
   dnf -y install --setopt=install_weak_deps=False \
-    awscli \
     ccache \
     createrepo_c \
     dosfstools \
@@ -884,10 +883,13 @@ RUN \
     efitools \
     erofs-utils \
     gdisk \
+    glibc \
     glib2-devel \
     gnupg-pkcs11-scd \
     gnutls-utils \
+    groff \
     kpartx \
+    less \
     libcap-devel \
     lz4 \
     mtools \
@@ -906,10 +908,32 @@ RUN \
     secilc \
     ShellCheck \
     squashfs-tools \
+    unzip \
     veritysetup \
     xfsprogs \
   && \
+  dnf -y remove awscli && \
   dnf clean all
+
+ARG HOST_ARCH
+ARG AWSCLI_VER="2.14.6"
+
+USER builder
+WORKDIR /home/builder/awscli
+COPY ./hashes/awscli /home/builder/awscli/hashes
+RUN \
+  sdk-fetch hashes && \
+  unzip awscli-exe-linux-${HOST_ARCH}-${AWSCLI_VER}.zip && \
+  rm awscli-exe-linux-*-${AWSCLI_VER}.zip
+
+USER root
+
+RUN \
+  ./aws/install && \
+  install -p -m 0644 -D -t \
+    /usr/share/licenses/awscli-${AWSCLI_VER} \
+    aws/THIRD_PARTY_LICENSES && \
+  rm -rf /home/builder
 
 # =^..^=   =^..^=   =^..^=   =^..^=   =^..^=   =^..^=   =^..^=   =^..^=   =^..^=
 

--- a/hashes/awscli
+++ b/hashes/awscli
@@ -1,0 +1,5 @@
+# https://awscli.amazonaws.com/awscli-exe-linux-aarch64-2.14.6.zip
+SHA512 (awscli-exe-linux-aarch64-2.14.6.zip) = e1212ab815925bf4c8ab1dfd857ee4aa04c281df3566b1ecd88e5873f81e6c7a1d6c9aac09c520a1c2a945041175912efb83a53f18a675c6f53474489891441b
+
+# https://awscli.amazonaws.com/awscli-exe-linux-x86_64-2.14.6.zip
+SHA512 (awscli-exe-linux-x86_64-2.14.6.zip) = f28c52f951bd32c1aa3e6ab8e6871f1453e7954a3d872ec932b531eef701bd4a4679d0840e6ba2eea75675344edc0b8545d9433af7e45bbe6d06440b6775a2dc


### PR DESCRIPTION
**Description of changes:**

This is necessary due to an incompatibility with IAM authentication and changes to `datetime` in Python 3.12.

**Testing done:**

- [x] Build SDK (and Bottlerocket) `x86_64` on `x86_64`
- [x] Build SDK (and Bottlerocket) `aarch64` on `x86_64`
- [x] Build SDK (and Bottlerocket) `aarch64` on `aarch64`
- [x] Build SDK (and Bottlerocket) `x86_64` on `aarch64`
- [x] Check `/usr/share/licenses/awscli-2.14.6/`
- [x] Verify versions with `aws --version`
- [x] Verify `generate-aws-sbkeys` doesn't return `can't compare offset-naive and offset-aware datetimes`



**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
