### PR TITLE
include go.env file at GOROOT expected by Go 1.21 and above

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1012,6 +1012,7 @@ COPY --chown=0:0 --from=sdk-go /home/builder/sdk-go/bin /usr/libexec/go/bin/
 COPY --chown=0:0 --from=sdk-go /home/builder/sdk-go/lib /usr/libexec/go/lib/
 COPY --chown=0:0 --from=sdk-go /home/builder/sdk-go/pkg /usr/libexec/go/pkg/
 COPY --chown=0:0 --from=sdk-go /home/builder/sdk-go/src /usr/libexec/go/src/
+COPY --chown=0:0 --from=sdk-go /home/builder/sdk-go/go.env /usr/libexec/go/go.env
 COPY --chown=0:0 --from=sdk-go \
   /home/builder/sdk-go/licenses/ \
   /usr/share/licenses/go/


### PR DESCRIPTION
**Issue number:** #153 



**Description of changes:**

Go 1.21 moved the definition of defaults of some `GO*` environment variables from source to a `go.env` configuration file [1]. Make sure to include that file in the final image, otherwise some variables like `GOPROXY` will have no value if not explicitly specified by the user, and builds using the SDK could fail.

Note this is not introducing opinionated new defaults, but rather just accommodating a change in the upstream Go release. Values for these variables explicitly specified by the user still take precedence.

[1]: https://github.com/golang/go/commit/7aa85e01376d840acc8bb931156d607a00b64a60



**Testing done:** x86_64 could build the x86_64 SDK. Inside the resulting image, `/usr/libexec/go/bin/go env GOPROXY` emitted the expected default `https://proxy.golang.org,direct`.

~I'm currently running builds for all architecture combinations to confirm this actually fixes https://github.com/bottlerocket-os/bottlerocket/issues/3698.~

With this change in the SDK, `cargo make purge-go-vendor` followed by `cargo make fetch-vendored` in the main Bottlerocket repository succeeds. Without it, it fails with `GOPROXY list is not the empty string` error.



**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
