### PR TITLE
add macros for /boot and boot config data

### DIFF
--- a/macros/shared
+++ b/macros/shared
@@ -23,6 +23,8 @@
 %_cross_ldflags -Wl,-z,relro -Wl,-z,now -Wl,-Bsymbolic-functions
 %_cross_c_link_args '-Wl,-z,relro', '-Wl,-z,now', '-Wl,-Bsymbolic-functions'
 
+%_cross_bootdir /boot
+%_cross_bootconfigdir %{_cross_bootdir}/boot-config.d
 %_cross_lib lib
 %_cross_rootdir /%{_cross_target}/sys-root
 %_cross_prefix %{_cross_rootdir}%{_prefix}


### PR DESCRIPTION
**Issue number:**
N/A


**Description of changes:**
Add macros for boot-related paths. This will support a forthcoming feature in twoliter's `rpm2img` to allow packages to contribute snippets to the default generated bootconfig file.


**Testing done:**
Used the macros and the corresponding twoliter change to specify `fips="1"` and `systemd.unified_cgroup_hierarchy="1"` via packaged bootconfig snippets.


**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
