### PR TITLE
support FIPS for Go builds

### DIFF
--- a/COPYRIGHT
+++ b/COPYRIGHT
@@ -17,3 +17,11 @@ operating system images.
 macros/rust and macros/cargo (used during build) are derived from the Fedora Rust SIG's rust2rpm.
 https://pagure.io/fedora-rust/rust2rpm
 Copyright (c) 2017 Igor Gnatenko. Licensed under the MIT License.
+
+=^..^=   =^..^=   =^..^=   =^..^=   =^..^=   =^..^=   =^..^=   =^..^=   =^..^=   =^..^=   =^..^=
+
+helpers/go/parse-functions.go, helpers/go/umod-arm64.c, and helpers/go/umod-amd64.s are derived
+from the Go project's build-goboring.sh:
+https://github.com/golang/go/blob/master/src/crypto/internal/boring/build-goboring.sh
+Copyright (c) 2020 The Go Authors. Licensed under a BSD-3-Clause license.
+See helpers/aws-lc/LICENSE.

--- a/Dockerfile
+++ b/Dockerfile
@@ -441,9 +441,10 @@ RUN \
 
 # =^..^=   =^..^=   =^..^=   =^..^=   =^..^=   =^..^=   =^..^=   =^..^=   =^..^=
 
-FROM sdk-libc as sdk-go
+FROM sdk-libc as sdk-go-prep
 
 ENV GOVER="1.22.1"
+ENV AWS_LC_FIPS_VER="2.0.9"
 
 USER root
 RUN dnf -y install golang
@@ -456,7 +457,31 @@ RUN \
   tar --strip-components=1 -xf go${GOVER}.src.tar.gz && \
   rm go${GOVER}.src.tar.gz
 
-ENV GOROOT_FINAL="/usr/libexec/go"
+# Patch Go sources so that they work with AWS-LC as the crypto implementation.
+# Note that this will break use of `GOEXPERIMENT=boringcrypto` when using the
+# default syso files that ship with Go, since the functions and data structures
+# will no longer match. We build the replacement AWS-LC syso files below.
+COPY patches/go/* ./
+RUN \
+  git init && \
+  git apply --whitespace=nowarn *.patch
+
+# We need to build AWS-LC before we can build Go.
+WORKDIR /home/builder/aws-lc
+COPY ./hashes/aws-lc /home/builder/hashes
+RUN \
+  sdk-fetch /home/builder/hashes && \
+  tar --strip-components=1 -xf AWS-LC-FIPS-${AWS_LC_FIPS_VER}.tar.gz && \
+  rm AWS-LC-FIPS-${AWS_LC_FIPS_VER}.tar.gz
+
+# Patch AWS-LC sources to avoid weak symbols for memory management functions
+# when GOBORING is defined.
+COPY patches/aws-lc/* ./
+RUN \
+  git init && \
+  git apply --whitespace=nowarn *.patch
+
+# Set up the environment for building.
 ENV GOOS="linux"
 ENV CGO_ENABLED=1
 ENV CFLAGS="-O2 -g -pipe -Wformat -Werror=format-security -Wp,-D_FORTIFY_SOURCE=2 -Wp,-D_GLIBCXX_ASSERTIONS -fexceptions -fstack-clash-protection"
@@ -466,6 +491,36 @@ ENV CGO_CFLAGS="${CFLAGS}"
 ENV CGO_CXXFLAGS="${CXXFLAGS}"
 ENV CGO_LDFLAGS="${LDFLAGS}"
 
+WORKDIR /home/builder/aws-lc/build
+COPY ./configs/aws-lc/* .
+COPY ./helpers/aws-lc/* .
+
+# =^..^=   =^..^=   =^..^=   =^..^=   =^..^=   =^..^=   =^..^=   =^..^=   =^..^=
+
+FROM sdk-go-prep as sdk-go-aws-lc-x86_64
+ENV ARCH="x86_64"
+RUN ./build-aws-lc.sh --arch="${ARCH}" --go-dir="${HOME}/sdk-go"
+
+# =^..^=   =^..^=   =^..^=   =^..^=   =^..^=   =^..^=   =^..^=   =^..^=   =^..^=
+
+FROM sdk-go-prep as sdk-go-aws-lc-aarch64
+ENV ARCH="aarch64"
+RUN ./build-aws-lc.sh --arch="${ARCH}" --go-dir="${HOME}/sdk-go"
+
+# =^..^=   =^..^=   =^..^=   =^..^=   =^..^=   =^..^=   =^..^=   =^..^=   =^..^=
+
+FROM sdk-go-prep as sdk-go
+
+COPY --from=sdk-go-aws-lc-x86_64 \
+  /home/builder/aws-lc/build/goboringcrypto_linux_amd64.syso \
+  /home/builder/sdk-go/src/crypto/internal/boring/syso/goboringcrypto_linux_amd64.syso
+
+COPY --from=sdk-go-aws-lc-aarch64 \
+  /home/builder/aws-lc/build/goboringcrypto_linux_arm64.syso \
+  /home/builder/sdk-go/src/crypto/internal/boring/syso/goboringcrypto_linux_arm64.syso
+
+# Build Go - finally!
+ENV GOROOT_FINAL="/usr/libexec/go"
 WORKDIR /home/builder/sdk-go/src
 RUN ./all.bash
 
@@ -1022,6 +1077,9 @@ COPY --chown=0:0 --from=sdk-go /home/builder/sdk-go/go.env /usr/libexec/go/go.en
 COPY --chown=0:0 --from=sdk-go \
   /home/builder/sdk-go/licenses/ \
   /usr/share/licenses/go/
+COPY --chown=0:0 --from=sdk-go \
+  /home/builder/aws-lc/LICENSE \
+  /usr/share/licenses/aws-lc/LICENSE
 
 # "sdk-rust-tools" has our attribution generation and license scan tools.
 COPY --chown=0:0 --from=sdk-rust-tools /usr/libexec/tools/ /usr/libexec/tools/

--- a/Dockerfile
+++ b/Dockerfile
@@ -1178,6 +1178,10 @@ RUN \
 RUN \
   ln -s ../libexec/go/bin/go /usr/bin/go && \
   ln -s ../libexec/go/bin/gofmt /usr/bin/gofmt && \
+  echo "#!/bin/bash" > /usr/bin/gofips && \
+  echo "export GOEXPERIMENT=boringcrypto" >> /usr/bin/gofips && \
+  echo 'exec /usr/libexec/go/bin/go "${@}"' >> /usr/bin/gofips && \
+  chmod +x /usr/bin/gofips && \
   find /usr/libexec/go -type f -exec touch -r /usr/libexec/go/bin/go {} \+
 
 # Strip and add tools to the path.

--- a/Dockerfile
+++ b/Dockerfile
@@ -1025,7 +1025,10 @@ RUN \
     platform_dir="/usr/lib/rpm/platform/${arch}-bottlerocket" ; \
     mkdir -p "${platform_dir}" ; \
     cat ${arch} shared rust cargo > "${platform_dir}/macros" ; \
-  done
+  done && \
+  vendor_dir="/usr/lib/rpm/bottlerocket" && \
+  mkdir -p "${vendor_dir}" && \
+  cp -a check-fips "${vendor_dir}"
 
 # =^..^=   =^..^=   =^..^=   =^..^=   =^..^=   =^..^=   =^..^=   =^..^=   =^..^=
 #
@@ -1146,6 +1149,10 @@ COPY --chown=0:0 --from=sdk-macros \
 COPY --chown=0:0 --from=sdk-macros \
   /usr/lib/rpm/platform/aarch64-bottlerocket/ \
   /usr/lib/rpm/platform/aarch64-bottlerocket/
+
+COPY --chown=0:0 --from=sdk-macros \
+  /usr/lib/rpm/bottlerocket/check-fips \
+  /usr/lib/rpm/bottlerocket/check-fips
 
 COPY --chown=0:0 --from=sdk-find-debuginfo-symlinks \
   /usr/x86_64-bottlerocket-linux-gnu/debuginfo/bin/ \

--- a/configs/aws-lc/aarch64-bottlerocket-linux-gnu.toolchain.cmake
+++ b/configs/aws-lc/aarch64-bottlerocket-linux-gnu.toolchain.cmake
@@ -1,0 +1,13 @@
+set(CMAKE_SYSTEM_NAME Linux)
+set(CMAKE_SYSTEM_PROCESSOR aarch64)
+
+set(CMAKE_SYSROOT /aarch64-bottlerocket-linux-gnu/sys-root)
+set(CMAKE_C_COMPILER aarch64-bottlerocket-linux-gnu-gcc)
+set(CMAKE_C_COMPILER_TARGET aarch64-bottlerocket-linux-gnu)
+set(CMAKE_CXX_COMPILER aarch64-bottlerocket-linux-gnu-g++)
+set(CMAKE_CXX_COMPILER_TARGET aarch64-bottlerocket-linux-gnu)
+
+set(CMAKE_FIND_ROOT_PATH_MODE_PROGRAM NEVER)
+set(CMAKE_FIND_ROOT_PATH_MODE_LIBRARY ONLY)
+set(CMAKE_FIND_ROOT_PATH_MODE_INCLUDE ONLY)
+set(CMAKE_FIND_ROOT_PATH_MODE_PACKAGE ONLY)

--- a/configs/aws-lc/x86_64-bottlerocket-linux-gnu.toolchain.cmake
+++ b/configs/aws-lc/x86_64-bottlerocket-linux-gnu.toolchain.cmake
@@ -1,0 +1,13 @@
+set(CMAKE_SYSTEM_NAME Linux)
+set(CMAKE_SYSTEM_PROCESSOR x86_64)
+
+set(CMAKE_SYSROOT /x86_64-bottlerocket-linux-gnu/sys-root)
+set(CMAKE_C_COMPILER x86_64-bottlerocket-linux-gnu-gcc)
+set(CMAKE_C_COMPILER_TARGET x86_64-bottlerocket-linux-gnu)
+set(CMAKE_CXX_COMPILER x86_64-bottlerocket-linux-gnu-g++)
+set(CMAKE_CXX_COMPILER_TARGET x86_64-bottlerocket-linux-gnu)
+
+set(CMAKE_FIND_ROOT_PATH_MODE_PROGRAM NEVER)
+set(CMAKE_FIND_ROOT_PATH_MODE_LIBRARY ONLY)
+set(CMAKE_FIND_ROOT_PATH_MODE_INCLUDE ONLY)
+set(CMAKE_FIND_ROOT_PATH_MODE_PACKAGE ONLY)

--- a/hashes/aws-lc
+++ b/hashes/aws-lc
@@ -1,0 +1,2 @@
+# https://github.com/aws/aws-lc/archive/refs/tags/AWS-LC-FIPS-2.0.9.tar.gz
+SHA512 (AWS-LC-FIPS-2.0.9.tar.gz) = 08481e8743b49d4461567c397d3d07e74845722176cc910a2ee08b9996f44cdc4f73569ece555f11d5ae6afb6de99452646057e8c3c6753d0a0f7e0c53615a32

--- a/helpers/aws-lc/LICENSE
+++ b/helpers/aws-lc/LICENSE
@@ -1,0 +1,28 @@
+Copyright (c) 2009 The Go Authors. All rights reserved.
+Copyright Amazon.com, Inc., its affiliates, or other contributors.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are
+met:
+
+   * Redistributions of source code must retain the above copyright
+notice, this list of conditions and the following disclaimer.
+   * Redistributions in binary form must reproduce the above
+copyright notice, this list of conditions and the following disclaimer
+in the documentation and/or other materials provided with the
+distribution.
+   * Neither the name of Google Inc. nor the names of its
+contributors may be used to endorse or promote products derived from
+this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/helpers/aws-lc/build-aws-lc.sh
+++ b/helpers/aws-lc/build-aws-lc.sh
@@ -1,0 +1,57 @@
+#!/usr/bin/env bash
+# shellcheck disable=SC2034
+
+set -eux -o pipefail
+shopt -qs failglob
+
+for opt in "$@"; do
+   optarg="$(expr "${opt}" : '[^=]*=\(.*\)')"
+   case "${opt}" in
+      --arch=*) ARCH="${optarg}" ;;
+      --go-dir=*) GODIR="${optarg}" ;;
+   esac
+done
+
+ARCH="${ARCH:?}"
+GODIR="${GODIR:?}"
+TARGET="${ARCH}-bottlerocket-linux-gnu"
+
+# Some of the AWS-LC sources are built with `-O0`. This is not compatible with
+# `-Wp,-D_FORTIFY_SOURCE=2`, which needs at least `-O2`. Add `-DGOBORING` to
+# avoid weak symbols.
+CFLAGS="${CFLAGS} -Wp,-U_FORTIFY_SOURCE -DGOBORING"
+
+cd "${HOME}/aws-lc/build"
+cmake \
+  -DCMAKE_BUILD_TYPE=Release \
+  -DCMAKE_TOOLCHAIN_FILE="${TARGET}.toolchain.cmake" \
+  -GNinja \
+  -DFIPS=1 \
+  ..
+ninja
+
+go run parse-functions.go \
+  "${GODIR}/src/crypto/internal/boring/goboringcrypto.h" .
+
+GOARCH_aarch64="arm64"
+GOARCH_x86_64="amd64"
+GOARCH_ARCH="GOARCH_${ARCH}"
+GOARCH="${!GOARCH_ARCH}"
+
+"${TARGET}-gcc" -c -o umod.o umod-"${GOARCH}".?
+
+"${TARGET}-objcopy" \
+  --globalize-symbol=BORINGSSL_bcm_power_on_self_test \
+  crypto/libcrypto.a libcrypto.a
+
+"${TARGET}-ld" \
+  -r -nostdlib --whole-archive \
+  -o goboringcrypto.o libcrypto.a umod.o
+
+"${TARGET}-objcopy" \
+  --redefine-syms=renames.txt \
+  goboringcrypto.o
+
+"${TARGET}-objcopy" \
+  --keep-global-symbols=globals.txt --strip-unneeded \
+  goboringcrypto.o "goboringcrypto_linux_${GOARCH}.syso"

--- a/helpers/aws-lc/parse-functions.go
+++ b/helpers/aws-lc/parse-functions.go
@@ -1,0 +1,105 @@
+// Adapted from the Go project's build-goboring.sh:
+//   https://github.com/golang/go/blob/master/src/crypto/internal/boring/build-goboring.sh
+
+// Original Copyright 2022 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+// Modifications Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+
+package main
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"regexp"
+	"strings"
+)
+
+var funcDefinition = regexp.MustCompile("^(const )?[^ ]+ \\**_goboringcrypto_([^(]*)\\(")
+
+var osWriteFile = os.WriteFile
+
+// main is responsible for parsing out the functions from the goboringcrypto.h file.
+// It writes it out in several formats to be used later for processing.
+func main() {
+	if len(os.Args) != 3 {
+		fmt.Println("usage: ", os.Args[0], " <path_to_goboringcrypto.h> <output_dir>")
+		os.Exit(1)
+	}
+
+	if err := writeFunctions(os.Args[1], os.Args[2]); err != nil {
+		fmt.Println(err)
+		os.Exit(1)
+	}
+}
+
+func writeFunctions(headerFile string, outputDir string) error {
+	syms, globals, renames, err := parse(headerFile)
+	if err != nil {
+		return err
+	}
+
+	// Write out our symbols file, ensuring it ends with a newline to prevent some unix tools from failing.
+	if err := osWriteFile(filepath.Join(outputDir, "syms.txt"), []byte(strings.Join(syms, "\n")+"\n"), 0644); err != nil {
+		return fmt.Errorf("failed writing syms.txt: %w", err)
+	}
+	// Write out our globals file, ensuring it ends with a newline to prevent some unix tools from failing.
+	if err := osWriteFile(filepath.Join(outputDir, "globals.txt"), []byte(strings.Join(globals, "\n")+"\n"), 0644); err != nil {
+		return fmt.Errorf("failed writing globals.txt: %w", err)
+	}
+	// Write out our renames file, ensuring it ends with a newline to prevent some unix tools from failing.
+	if err := osWriteFile(filepath.Join(outputDir, "renames.txt"), []byte(strings.Join(renames, "\n")+"\n"), 0644); err != nil {
+		return fmt.Errorf("failed writing renames.txt: %w", err)
+	}
+
+	return nil
+}
+
+func parse(headerFile string) ([]string, []string, []string, error) {
+	// Load our header file and break it into lines for processing.
+	data, err := os.ReadFile(headerFile)
+	if err != nil {
+		return nil, nil, nil, fmt.Errorf("failed reading %q: %w", headerFile, err)
+	}
+
+	// Locate the functions from the header file that we are interested in.
+	syms, err := locateFunctions(strings.Split(string(data), "\n"))
+	if err != nil {
+		return nil, nil, nil, err
+	}
+
+	// Add extra functions that aren't in the header.
+	syms = append(syms, "BORINGSSL_bcm_power_on_self_test")
+	globals, renames := generateGlobalsRenames(syms)
+
+	return syms, globals, renames, nil
+}
+
+func generateGlobalsRenames(syms []string) ([]string, []string) {
+	globals := make([]string, 0, len(syms))
+	renames := make([]string, 0, len(syms)+2)
+	for _, sym := range syms {
+		globals = append(globals, "_goboringcrypto_"+sym)
+		renames = append(renames, sym+" _goboringcrypto_"+sym)
+	}
+
+	// Add the functions that we manually compile in.
+	renames = append(renames, "__umodti3 _goboringcrypto___umodti3", "__udivti3 _goboringcrypto___udivti3")
+
+	return globals, renames
+}
+
+func locateFunctions(lines []string) ([]string, error) {
+	funcs := make([]string, 0, len(lines))
+	for _, line := range lines {
+		match := funcDefinition.FindStringSubmatch(line)
+		if len(match) == 0 {
+			continue
+		}
+		funcs = append(funcs, match[2])
+	}
+
+	return funcs, nil
+}

--- a/helpers/aws-lc/umod-amd64.s
+++ b/helpers/aws-lc/umod-amd64.s
@@ -1,0 +1,39 @@
+# Copyright 2020 The Go Authors. All rights reserved.
+# Use of this source code is governed by a BSD-style
+# license that can be found in the LICENSE file.
+
+# tu_int __umodti3(tu_int x, tu_int y)
+# x is rsi:rdi, y is rcx:rdx, return result is rdx:rax.
+.globl __umodti3
+__umodti3:
+	# specialized to u128 % u64, so verify that
+	test %rcx,%rcx
+	jne 1f
+
+	# save divisor
+	movq %rdx, %r8
+
+	# reduce top 64 bits mod divisor
+	movq %rsi, %rax
+	xorl %edx, %edx
+	divq %r8
+
+	# reduce full 128-bit mod divisor
+	# quotient fits in 64 bits because top 64 bits have been reduced < divisor.
+	# (even though we only care about the remainder, divq also computes
+	# the quotient, and it will trap if the quotient is too large.)
+	movq %rdi, %rax
+	divq %r8
+
+	# expand remainder to 128 for return
+	movq %rdx, %rax
+	xorl %edx, %edx
+	ret
+
+1:
+	# crash - only want 64-bit divisor
+	xorl %ecx, %ecx
+	movl %ecx, 0(%ecx)
+	jmp 1b
+
+.section .note.GNU-stack,"",@progbits

--- a/helpers/aws-lc/umod-arm64.c
+++ b/helpers/aws-lc/umod-arm64.c
@@ -1,0 +1,35 @@
+// Copyright 2022 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+typedef unsigned int u128 __attribute__((mode(TI)));
+
+static u128 div(u128 x, u128 y, u128 *rp) {
+	int n = 0;
+	while((y>>(128-1)) != 1 && y < x) {
+		y<<=1;
+		n++;
+	}
+	u128 q = 0;
+	for(;; n--, y>>=1, q<<=1) {
+		if(x>=y) {
+			x -= y;
+			q |= 1;
+		}
+		if(n == 0)
+			break;
+	}
+	if(rp)
+		*rp = x;
+	return q;
+}
+
+u128 __umodti3(u128 x, u128 y) {
+	u128 r;
+	div(x, y, &r);
+	return r;
+}
+
+u128 __udivti3(u128 x, u128 y) {
+	return div(x, y, 0);
+}

--- a/macros/check-fips
+++ b/macros/check-fips
@@ -1,0 +1,88 @@
+#!/bin/bash
+
+set -euo pipefail
+shopt -qs failglob
+
+for opt in "$@"; do
+   optarg="$(expr "${opt}" : '[^=]*=\(.*\)')"
+   case "${opt}" in
+      --target=*) TARGET="${optarg}" ;;
+      --bindir=*) BINDIR="${optarg}" ;;
+      --fips-bindir=*) FIPS_BINDIR="${optarg}" ;;
+      --libexecdir=*) LIBEXECDIR="${optarg}" ;;
+      --fips-libexecdir=*) FIPS_LIBEXECDIR="${optarg}" ;;
+   esac
+done
+
+STRINGS="${TARGET}-strings"
+BUILDROOT_BINDIR="${RPM_BUILD_ROOT}${BINDIR}"
+BUILDROOT_FIPS_BINDIR="${RPM_BUILD_ROOT}${FIPS_BINDIR}"
+BUILDROOT_LIBEXECDIR="${RPM_BUILD_ROOT}${LIBEXECDIR}"
+BUILDROOT_FIPS_LIBEXECDIR="${RPM_BUILD_ROOT}${FIPS_LIBEXECDIR}"
+
+if [ ! -d "${BUILDROOT_BINDIR}" ] && [ ! -d "${BUILDROOT_LIBEXECDIR}" ] ; then
+  echo "no binaries found, skipping FIPS check"
+  exit 0
+fi
+
+is_go_bin() {
+  local bin
+  bin="${1:?}"
+  go version "${bin}" 2>&1 | grep -Fqw -v 'not a Go executable'
+}
+
+uses_go_crypto_tls() {
+  local bin output
+  bin="${1:?}"
+  output="$("${STRINGS}" "${bin}")"
+  grep -Fqw -m1 'crypto/tls' <<<"${output}"
+}
+
+uses_go_boring_crypto() {
+  local bin output
+  bin="${1:?}"
+  output="$("${STRINGS}" "${bin}")"
+  grep -Fq -m1 'goboringcrypto' <<<"${output}"
+}
+
+found=0
+not_found=0
+miscompiled=0
+for b in $(find "${BUILDROOT_BINDIR}" "${BUILDROOT_LIBEXECDIR}" -type f -executable) ; do
+  if is_go_bin "${b}" && uses_go_crypto_tls "${b}" ; then
+    f="${b/${BUILDROOT_BINDIR}/${BUILDROOT_FIPS_BINDIR}}"
+    f="${f/${BUILDROOT_LIBEXECDIR}/${BUILDROOT_FIPS_LIBEXECDIR}}"
+    if [ -s "${f}" ] ; then
+      echo "${b} uses Go crypto/tls and FIPS build found in ${f}"
+      (( found+=1 ))
+      if uses_go_boring_crypto "${b}" ; then
+        echo "${b} is built with FIPS crypto rather than standard crypto" >&2
+        (( miscompiled+=1 ))
+      fi
+      if ! uses_go_boring_crypto "${f}"; then
+        echo "${f} is built with standard crypto rather than FIPS crypto" >&2
+        (( miscompiled+=1 ))
+      fi
+    else
+      echo "${b} uses Go crypto/tls but no FIPS build found in ${f}" >&2
+      (( not_found+=1 ))
+    fi
+  fi
+done
+
+if [ "${found}" -gt 0 ] ; then
+  [ "${found}" -eq 1 ] && what="binary" || what="binaries"
+  echo "Found ${found} ${what} built for FIPS."
+fi
+
+if [ "${not_found}" -gt 0 ] ; then
+  [ "${not_found}" -eq 1 ] && what="binary" || what="binaries"
+  echo "Could not find ${not_found} ${what} built for FIPS." >&2
+  exit 1
+fi
+
+if [ "${miscompiled}" -gt 0 ] ; then
+  [ "${miscompiled}" -eq 1 ] && what="binary" || what="binaries"
+  echo "Found ${miscompiled} ${what} using the wrong crypto." >&2
+  exit 1
+fi

--- a/macros/shared
+++ b/macros/shared
@@ -31,8 +31,10 @@
 %_cross_exec_prefix %{_cross_rootdir}%{_exec_prefix}
 %_cross_bindir %{_cross_rootdir}%{_bindir}
 %_cross_sbindir %{_cross_rootdir}%{_sbindir}
+%_cross_fips_bindir %{_cross_rootdir}%{_prefix}/fips/bin
 %_cross_libdir %{_cross_prefix}/%{_cross_lib}
 %_cross_libexecdir %{_cross_rootdir}%{_libexecdir}
+%_cross_fips_libexecdir %{_cross_rootdir}%{_prefix}/fips/libexec
 %_cross_includedir %{_cross_rootdir}%{_includedir}
 %_cross_sysconfdir %{_sysconfdir}
 %_cross_tmpfilesdir %{_cross_rootdir}%{_tmpfilesdir}
@@ -241,8 +243,21 @@ CROSS_COMPILATION_CONF_EOF\
 %_source_payload w1.zstdio
 %_binary_payload w1.zstdio
 
+# Invocation for the check-fips buildroot policy script.
+%__cross_check_fips_cmd %{shrink: \
+  /usr/lib/rpm/bottlerocket/check-fips \
+    --target="%{_cross_target}" \
+    --bindir="%{_cross_bindir}" \
+    --fips-bindir="%{_cross_fips_bindir}" \
+    --libexecdir="%{_cross_libexecdir}" \
+    --fips-libexecdir="%{_cross_fips_libexecdir}" \
+    %{nil}}
+
+# Generate license attribution and check for FIPS-enabled binaries.
+# (The FIPS check is disabled by default, pending tree-wide packaging changes.)
 %__arch_install_post \
   /usr/lib/rpm/check-buildroot \
+  %{?cross_check_fips:%{__cross_check_fips_cmd}} \
   %cross_generate_attribution
 
 %source_date_epoch_from_changelog 0

--- a/macros/shared
+++ b/macros/shared
@@ -172,27 +172,39 @@ CROSS_COMPILATION_CONF_EOF\
 
 %_cross_go_os linux
 
-%set_cross_go_flags \
+%set_cross_go_env() \
+  CROSS_TARGET="%1" ; export CROSS_TARGET ; \
   GOPATH="${PWD}/GOPATH" ; export GOPATH ; \
   GOOS="%{_cross_go_os}" ; export GOOS ; \
   GOARCH="%{_cross_go_arch}" ; export GOARCH ; \
-  CC="%{_cross_target}-gcc" ; export CC ; \
-  CC_FOR_TARGET="%{_cross_target}-gcc" ; export CC_FOR_TARGET ; \
-  CC_FOR_%{_cross_go_os}_%{_cross_go_arch}="%{_cross_target}-gcc" ; export CC_FOR_%{_cross_go_os}_%{_cross_go_arch} ; \
-  CXX="%{_cross_target}-g++" ; export CXX ; \
-  CXX_FOR_TARGET="%{_cross_target}-g++" ; export CXX_FOR_TARGET ; \
-  CXX_FOR_%{_cross_go_os}_%{_cross_go_arch}="%{_cross_target}-g++" ; export CXX_FOR_%{_cross_go_os}_%{_cross_go_arch} ; \
+  CC="%1-gcc" ; export CC ; \
+  CC_FOR_TARGET="%1-gcc" ; export CC_FOR_TARGET ; \
+  CC_FOR_%{_cross_go_os}_%{_cross_go_arch}="%1-gcc" ; export CC_FOR_%{_cross_go_os}_%{_cross_go_arch} ; \
+  CXX="%1-g++" ; export CXX ; \
+  CXX_FOR_TARGET="%1-g++" ; export CXX_FOR_TARGET ; \
+  CXX_FOR_%{_cross_go_os}_%{_cross_go_arch}="%1-g++" ; export CXX_FOR_%{_cross_go_os}_%{_cross_go_arch} ; \
   CGO_ENABLED=1 ; export CGO_ENABLED ; \
   CGO_CFLAGS="%{_cross_cflags}" ; export CGO_CFLAGS ; \
   CGO_CXXFLAGS="%{_cross_cxxflags}" ; export CGO_CXXFLAGS ; \
   CGO_LDFLAGS="%{_cross_ldflags}" ; export CGO_LDFLAGS ; \
   PKG_CONFIG_PATH="%{_cross_pkgconfigdir}" ; export PKG_CONFIG_PATH ; \
   PKG_CONFIG_ALLOW_CROSS=1 ; export PKG_CONFIG_ALLOW_CROSS ; \
-  GOFLAGS="-mod=vendor"; export GOFLAGS ; \
-  GOLDFLAGS="-compressdwarf=false -linkmode=external" ; export GOLDFLAGS ; \
+  GOFLAGS="-mod=vendor -a -buildmode=pie"; export GOFLAGS ; \
+  GOLDFLAGS_INT="-compressdwarf=false -linkmode=external" ; export GOLDFLAGS_INT ; \
+  GOLDFLAGS_EXT="%{expand:%%%2}" ; export GOLDFLAGS_EXT ; \
+  GOLDFLAGS="${GOLDFLAGS_INT} -extldflags '${GOLDFLAGS_EXT}'" ; export GOLDFLAGS ; \
   GOPROXY="off"; export GOPROXY ; \
   GOSUMDB="off"; export GOSUMDB ; \
   GO111MODULE="auto"; export GO111MODULE ; \
+
+%_cross_go_extldflags %{_cross_ldflags}
+%_cross_go_extldflags_static %{_cross_ldflags} -static-pie
+
+%set_cross_go_flags \
+  %set_cross_go_env %{_cross_target} _cross_go_extldflags
+
+%set_cross_go_flags_static \
+  %set_cross_go_env %{_cross_triple}-musl _cross_go_extldflags_static
 
 %cross_go_setup() \
   mkdir -p GOPATH/src/%2 ; \

--- a/patches/aws-lc/0001-Avoid-weak-symbols-when-building-for-Go.patch
+++ b/patches/aws-lc/0001-Avoid-weak-symbols-when-building-for-Go.patch
@@ -1,0 +1,34 @@
+From 0fb9b17aa5d0d63d17e6914f7c34358db69e5647 Mon Sep 17 00:00:00 2001
+From: Ben Cressey <bcressey@amazon.com>
+Date: Thu, 4 Jan 2024 18:07:33 +0000
+Subject: [PATCH] Avoid weak symbols when building for Go.
+
+Avoids runtime errors like this when Go and the native toolchain do
+not handle weak symbols correctly:
+ symbol lookup error: undefined symbol: OPENSSL_memory_free
+
+This is functionally equivalent to logic in the upstream Go project's
+script to build BoringSSL:
+  https://github.com/golang/go/blob/master/src/crypto/internal/boring/build-boring.sh
+
+Signed-off-by: Ben Cressey <bcressey@amazon.com>
+---
+ crypto/mem.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/crypto/mem.c b/crypto/mem.c
+index a580bbf46..a476dfc4f 100644
+--- a/crypto/mem.c
++++ b/crypto/mem.c
+@@ -86,7 +86,7 @@ static void __asan_unpoison_memory_region(const void *addr, size_t size) {}
+ // Windows doesn't really support weak symbols as of May 2019, and Clang on
+ // Windows will emit strong symbols instead. See
+ // https://bugs.llvm.org/show_bug.cgi?id=37598
+-#if defined(__ELF__) && defined(__GNUC__)
++#if defined(__ELF__) && defined(__GNUC__) && !defined(GOBORING)
+ #define WEAK_SYMBOL_FUNC(rettype, name, args) \
+   rettype name args __attribute__((weak));
+ #else
+-- 
+2.43.0
+

--- a/patches/go/0001-Make-boringcypto-build-compatible-with-aws-lc.patch
+++ b/patches/go/0001-Make-boringcypto-build-compatible-with-aws-lc.patch
@@ -1,0 +1,60 @@
+From de7e50742be2227a2a87a60dd140ddc8bd4fd4cc Mon Sep 17 00:00:00 2001
+From: Ben Cressey <bcressey@amazon.com>
+Date: Thu, 4 Jan 2024 19:14:46 +0000
+Subject: [PATCH] Make boringcypto build compatible with aws-lc
+
+Signed-off-by: Dusan Kostic <dkostic@amazon.com>
+Signed-off-by: Erikson Tung <etung@amazon.com>
+Signed-off-by: Ben Cressey <bcressey@amazon.com>
+---
+ src/crypto/internal/boring/goboringcrypto.h | 6 +++---
+ src/crypto/internal/boring/rsa.go           | 2 +-
+ 2 files changed, 4 insertions(+), 4 deletions(-)
+
+diff --git a/src/crypto/internal/boring/goboringcrypto.h b/src/crypto/internal/boring/goboringcrypto.h
+index 2b11049..5ac467c 100644
+--- a/src/crypto/internal/boring/goboringcrypto.h
++++ b/src/crypto/internal/boring/goboringcrypto.h
+@@ -84,7 +84,7 @@ int _goboringcrypto_EVP_MD_type(const GO_EVP_MD*);
+ size_t _goboringcrypto_EVP_MD_size(const GO_EVP_MD*);
+ 
+ // #include <openssl/hmac.h>
+-typedef struct GO_HMAC_CTX { char data[104]; } GO_HMAC_CTX;
++typedef struct GO_HMAC_CTX { char data[672]; } GO_HMAC_CTX;
+ void _goboringcrypto_HMAC_CTX_init(GO_HMAC_CTX*);
+ void _goboringcrypto_HMAC_CTX_cleanup(GO_HMAC_CTX*);
+ int _goboringcrypto_HMAC_Init(GO_HMAC_CTX*, const void*, int, const GO_EVP_MD*);
+@@ -199,7 +199,7 @@ int _goboringcrypto_ECDSA_verify(int, const uint8_t*, size_t, const uint8_t*, si
+ // #include <openssl/rsa.h>
+ 
+ // Note: order of struct fields here is unchecked.
+-typedef struct GO_RSA { void *meth; GO_BIGNUM *n, *e, *d, *p, *q, *dmp1, *dmq1, *iqmp; char data[168]; } GO_RSA;
++typedef struct GO_RSA { void *meth; GO_BIGNUM *n, *e, *d, *p, *q, *dmp1, *dmq1, *iqmp; char data[176]; } GO_RSA;
+ /*unchecked (opaque)*/ typedef struct GO_BN_GENCB { char data[1]; } GO_BN_GENCB;
+ GO_RSA* _goboringcrypto_RSA_new(void);
+ void _goboringcrypto_RSA_free(GO_RSA*);
+@@ -216,7 +216,7 @@ enum {
+ };
+ int _goboringcrypto_RSA_encrypt(GO_RSA*, size_t *out_len, uint8_t *out, size_t max_out, const uint8_t *in, size_t in_len, int padding);
+ int _goboringcrypto_RSA_decrypt(GO_RSA*, size_t *out_len, uint8_t *out, size_t max_out, const uint8_t *in, size_t in_len, int padding);
+-int _goboringcrypto_RSA_sign(int hash_nid, const uint8_t* in, unsigned int in_len, uint8_t *out, unsigned int *out_len, GO_RSA*);
++int _goboringcrypto_RSA_sign(int hash_nid, const uint8_t* in, unsigned long in_len, uint8_t *out, unsigned int *out_len, GO_RSA*);
+ int _goboringcrypto_RSA_sign_pss_mgf1(GO_RSA*, size_t *out_len, uint8_t *out, size_t max_out, const uint8_t *in, size_t in_len, const GO_EVP_MD *md, const GO_EVP_MD *mgf1_md, int salt_len);
+ int _goboringcrypto_RSA_sign_raw(GO_RSA*, size_t *out_len, uint8_t *out, size_t max_out, const uint8_t *in, size_t in_len, int padding);
+ int _goboringcrypto_RSA_verify(int hash_nid, const uint8_t *msg, size_t msg_len, const uint8_t *sig, size_t sig_len, GO_RSA*);
+diff --git a/src/crypto/internal/boring/rsa.go b/src/crypto/internal/boring/rsa.go
+index fa693ea..3057e93 100644
+--- a/src/crypto/internal/boring/rsa.go
++++ b/src/crypto/internal/boring/rsa.go
+@@ -340,7 +340,7 @@ func SignRSAPKCS1v15(priv *PrivateKeyRSA, h crypto.Hash, hashed []byte) ([]byte,
+ 	var outLen C.uint
+ 	if priv.withKey(func(key *C.GO_RSA) C.int {
+ 		out = make([]byte, C._goboringcrypto_RSA_size(key))
+-		return C._goboringcrypto_RSA_sign(nid, base(hashed), C.uint(len(hashed)),
++		return C._goboringcrypto_RSA_sign(nid, base(hashed), C.ulong(len(hashed)),
+ 			base(out), &outLen, key)
+ 	}) == 0 {
+ 		return nil, fail("RSA_sign")
+-- 
+2.43.0
+

--- a/patches/go/0002-Always-restrict-boringcrypto-crypto-tls-to-FIPS.patch
+++ b/patches/go/0002-Always-restrict-boringcrypto-crypto-tls-to-FIPS.patch
@@ -1,0 +1,38 @@
+From 11e8de79f810f02dc426d184b6eb54c011f09aa6 Mon Sep 17 00:00:00 2001
+From: Ben Cressey <bcressey@amazon.com>
+Date: Wed, 13 Mar 2024 18:16:53 +0000
+Subject: [PATCH] Always restrict boringcrypto crypto/tls to FIPS
+
+Signed-off-by: Ben Cressey <bcressey@amazon.com>
+---
+ src/crypto/tls/boring.go  | 1 +
+ src/go/build/deps_test.go | 1 +
+ 2 files changed, 2 insertions(+)
+
+diff --git a/src/crypto/tls/boring.go b/src/crypto/tls/boring.go
+index 1827f76..625a67c 100644
+--- a/src/crypto/tls/boring.go
++++ b/src/crypto/tls/boring.go
+@@ -8,6 +8,7 @@ package tls
+ 
+ import (
+ 	"crypto/internal/boring/fipstls"
++	_ "crypto/tls/fipsonly"
+ )
+ 
+ // needFIPS returns fipstls.Required(); it avoids a new import in common.go.
+diff --git a/src/go/build/deps_test.go b/src/go/build/deps_test.go
+index 592f2fd..5584339 100644
+--- a/src/go/build/deps_test.go
++++ b/src/go/build/deps_test.go
+@@ -482,6 +482,7 @@ var depsRules = `
+ 	< crypto/x509/internal/macos
+ 	< crypto/x509/pkix;
+ 
++	crypto/tls/fipsonly,
+ 	crypto/internal/boring/fipstls, crypto/x509/pkix
+ 	< crypto/x509
+ 	< crypto/tls;
+-- 
+2.43.0
+

--- a/tools/update-aws-lc.sh
+++ b/tools/update-aws-lc.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+
+set -e
+
+if [[ $# -lt 1 ]]; then
+    echo "Usage: $0 $AWS_LC_VERSION"
+    echo
+    echo "Example: $0 2.0.9"
+    exit 2
+fi
+
+TOOLSDIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+ROOTDIR=$(realpath "${TOOLSDIR}/..")
+
+VERSION="${1}"
+OUTPUT="${ROOTDIR}/hashes/aws-lc"
+
+# Get the AWS-LC-FIPS source package
+# e.g. FIXME
+AWS_LC_SRC_PACKAGE="AWS-LC-FIPS-${VERSION}.tar.gz"
+AWS_LC_SRC_URL="https://github.com/aws/aws-lc/archive/refs/tags/${AWS_LC_SRC_PACKAGE}"
+
+curl -s -L -O -C - "${AWS_LC_SRC_URL}"
+
+AWS_LC_512_SHA=$(sha512sum "${AWS_LC_SRC_PACKAGE}" | cut -d ' ' -f 1)
+
+# Add the root/header information
+echo "# ${AWS_LC_SRC_URL}" > "${OUTPUT}"
+echo "SHA512 (${AWS_LC_SRC_PACKAGE}) = ${AWS_LC_512_SHA}" >> "${OUTPUT}"
+
+DOCKERFILE="${ROOTDIR}/Dockerfile"
+sed -i -e "s,^ENV AWS_LC_FIPS_VER=.*,ENV AWS_LC_FIPS_VER=\"${VERSION}\",g" "${DOCKERFILE}"
+
+echo "================================================"
+echo "AWS-LC updated to ${VERSION}"
+echo "================================================"


### PR DESCRIPTION
**Issue number:**
Related: https://github.com/bottlerocket-os/bottlerocket/issues/1667


**Description of changes:**
Conceptually this patch series has two halves.

The first half consists of patching Go, patching AWS-LC, building AWS-LC sysos, then building Go with those sysos instead of the stock "boringcrypto" ones. All of this is done so that `GOEXPERIMENT=boringcrypto go build ...` does the right thing. This extends the earlier unified SDK work in that we're able to replace the sysos for both amd64 and arm64, so the Go toolchain should just work for both architectures whether or not the "boringcrypto" experiment is enabled.

The second half makes it easier to use `GOEXPERIMENT=boringcrypto go build ...` in downstream packaging of Go binaries. There are new macros, including a new way to set up the environment for static builds, and a lint script that checks whether all Go binaries that should be are built in a parallel version with FIPS enabled. That script is currently disabled by default: it can be enabled on a per-package basis for testing, and will be enabled by default in a future SDK release, after packaging has a chance to catch up.

These changes should be backwards compatible with existing packaging - the AWS-LC bits are only used when `GOEXPERIMENT=boringcrypto` is set, the new lint doesn't run by default, and the old `%set_cross_go_flags` is mostly unchanged.

**Testing done:**
Made all the packaging changes required with a slightly different build where the lint script was on by default. (It helped me catch a ton of problems!) See https://github.com/bcressey/bottlerocket/commits/fips-and-non-fips/ for what this looks like in action with the (forthcoming) twoliter changes as well.

Built and launched `aws-k8s-1.28` AMIs where only the FIPS versions of Go binaries were used. The nodes came up, joined the cluster, ran pods, etc.


**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
