### PR TITLE
update Rust and cargo-deny

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -527,7 +527,7 @@ RUN cargo build --release --locked
 
 FROM sdk-cargo as sdk-cargo-deny
 
-ENV DENYVER="0.13.5"
+ENV DENYVER="0.14.20"
 
 USER builder
 WORKDIR /home/builder

--- a/Dockerfile
+++ b/Dockerfile
@@ -339,7 +339,7 @@ RUN \
 
 ARG HOST_ARCH
 ENV VENDOR="bottlerocket"
-ENV RUSTVER="1.76.0"
+ENV RUSTVER="1.77.0"
 
 USER builder
 WORKDIR /home/builder

--- a/configs/cargo-deny/clarify.toml
+++ b/configs/cargo-deny/clarify.toml
@@ -18,7 +18,7 @@ license-files = [
 [clarify.bstr]
 expression = "(MIT OR Apache-2.0) AND Unicode-DFS-2016"
 license-files = [
-    { path = "COPYING", hash = 0x28398560 },
+    { path = "COPYING", hash = 0x278afbcf },
     { path = "LICENSE-APACHE", hash = 0x24b54f4b },
     { path = "LICENSE-MIT", hash = 0x462dee44 },
     { path = "src/unicode/data/LICENSE-UNICODE", hash = 0x70f7339 },
@@ -34,6 +34,8 @@ license-files = [
 skip-files = [
     "tests/LICENSE-RING",
     "tests/LICENSE-SUMMARY",
+    "tests/test_data/so-annoying/LICENSE-APACHE",
+    "tests/test_data/so-annoying/LICENSE-PIXAR",
 ]
 
 [clarify.crossbeam-channel]
@@ -140,15 +142,10 @@ skip-files = [
 ]
 
 [clarify.regex-automata]
-expression = "Unlicense OR MIT"
+expression = "MIT OR Apache-2.0"
 license-files = [
-    { path = "COPYING", hash = 0x969f37d8 },
-    { path = "LICENSE-MIT", hash = 0x616d8a83 },
-    { path = "UNLICENSE", hash = 0x87b84020 },
-]
-skip-files = [
-    "data/fowler-tests/LICENSE", # we aren't using the test data
-    "data/tests/fowler/LICENSE",
+    { path = "LICENSE-MIT", hash = 0xb755395b },
+    { path = "LICENSE-APACHE", hash = 0x24b54f4b },
 ]
 
 [clarify.regex-syntax]
@@ -159,6 +156,16 @@ license-files = [
     { path = "src/unicode_tables/LICENSE-UNICODE", hash = 0xa7f28b93 },
 ]
 
+[clarify.rustsec]
+expression = "MIT OR Apache-2.0"
+license-files = [
+    { path = "LICENSE-APACHE", hash = 0x24b54f4b },
+    { path = "LICENSE-MIT", hash = 0xb2666a2c },
+]
+skip-files = [
+    "src/advisory/license.rs",
+]
+
 [clarify.spdx]
 expression = "MIT OR Apache-2.0"
 license-files = [
@@ -167,6 +174,7 @@ license-files = [
 ]
 # skip files that contain the text of licenses
 skip-files = [
+    "src/text/exceptions/GPL-3.0-interface-exception",
     "src/text/exceptions/GPL-3.0-linking-exception",
     "src/text/exceptions/GPL-3.0-linking-source-exception",
     "src/text/exceptions/GPL-CC-1.0",
@@ -179,13 +187,17 @@ skip-files = [
     "src/text/licenses/AGPL-3.0-or-later",
     "src/text/licenses/BSD-1-Clause",
     "src/text/licenses/BSD-2-Clause",
+    "src/text/licenses/BSD-2-Clause-Darwin",
     "src/text/licenses/BSD-2-Clause-FreeBSD",
     "src/text/licenses/BSD-2-Clause-NetBSD",
     "src/text/licenses/BSD-2-Clause-Patent",
     "src/text/licenses/BSD-2-Clause-Views",
     "src/text/licenses/BSD-3-Clause",
+    "src/text/licenses/BSD-3-Clause-acpica",
     "src/text/licenses/BSD-3-Clause-Attribution",
     "src/text/licenses/BSD-3-Clause-Clear",
+    "src/text/licenses/BSD-3-Clause-flex",
+    "src/text/licenses/BSD-3-Clause-HP",
     "src/text/licenses/BSD-3-Clause-LBNL",
     "src/text/licenses/BSD-3-Clause-Modification",
     "src/text/licenses/BSD-3-Clause-No-Military-License",
@@ -193,15 +205,20 @@ skip-files = [
     "src/text/licenses/BSD-3-Clause-No-Nuclear-License-2014",
     "src/text/licenses/BSD-3-Clause-No-Nuclear-Warranty",
     "src/text/licenses/BSD-3-Clause-Open-MPI",
+    "src/text/licenses/BSD-3-Clause-Sun",
     "src/text/licenses/BSD-4-Clause",
     "src/text/licenses/BSD-4-Clause-Shortened",
     "src/text/licenses/BSD-4-Clause-UC",
+    "src/text/licenses/BSD-4.3RENO",
+    "src/text/licenses/BSD-4.3TAHOE",
+    "src/text/licenses/BSD-Systemics-W3Works",
     "src/text/licenses/CC-BY-1.0",
     "src/text/licenses/CC-BY-2.0",
     "src/text/licenses/CC-BY-2.5",
     "src/text/licenses/CC-BY-2.5-AU",
     "src/text/licenses/CC-BY-3.0",
     "src/text/licenses/CC-BY-3.0-AT",
+    "src/text/licenses/CC-BY-3.0-AU",
     "src/text/licenses/CC-BY-3.0-DE",
     "src/text/licenses/CC-BY-3.0-IGO",
     "src/text/licenses/CC-BY-3.0-NL",
@@ -222,6 +239,7 @@ skip-files = [
     "src/text/licenses/CC-BY-NC-ND-4.0",
     "src/text/licenses/CC-BY-NC-SA-1.0",
     "src/text/licenses/CC-BY-NC-SA-2.0",
+    "src/text/licenses/CC-BY-NC-SA-2.0-DE",
     "src/text/licenses/CC-BY-NC-SA-2.0-FR",
     "src/text/licenses/CC-BY-NC-SA-2.0-UK",
     "src/text/licenses/CC-BY-NC-SA-2.5",
@@ -243,6 +261,7 @@ skip-files = [
     "src/text/licenses/CC-BY-SA-3.0",
     "src/text/licenses/CC-BY-SA-3.0-AT",
     "src/text/licenses/CC-BY-SA-3.0-DE",
+    "src/text/licenses/CC-BY-SA-3.0-IGO",
     "src/text/licenses/CC-BY-SA-4.0",
     "src/text/licenses/GFDL-1.1",
     "src/text/licenses/GFDL-1.1-invariants-only",
@@ -320,7 +339,7 @@ license-files = [
 [clarify.unicode-ident]
 expression = "(MIT OR Apache-2.0) AND Unicode-DFS-2016"
 license-files = [
-    { path = "LICENSE-APACHE", hash = 0x24b54f4b },
+    { path = "LICENSE-APACHE", hash = 0xb5518783 },
     { path = "LICENSE-MIT", hash = 0x386ca1bc },
     { path = "LICENSE-UNICODE", hash = 0x9698cbbe },
 ]
@@ -347,7 +366,8 @@ license-files = [
     { path = "LICENSE", hash = 0x742401ae },
     { path = "LICENSE.Apache-2.0", hash = 0x7b466be4 },
     { path = "LICENSE.Mit", hash = 0xa237d234 },
-    { path = "zstd/LICENSE", hash = 0x79cda15 },
+    { path = "LICENSE.BSD-3-Clause", hash = 0xc9f5c4f6 },
+    { path = "zstd/LICENSE", hash = 0x3bfe1fb1 },
 ]
 skip-files = [
     "zstd/COPYING", # copy of the GPLv2 we are not choosing from libzstd's dual license

--- a/configs/cargo-deny/deny.toml
+++ b/configs/cargo-deny/deny.toml
@@ -1,10 +1,4 @@
 [licenses]
-unlicensed = "deny"
-
-# Deny licenses unless they are specifically listed here
-copyleft = "deny"
-allow-osi-fsf-free = "neither"
-default = "deny"
 
 # We want really high confidence when inferring licenses from text
 confidence-threshold = 0.93

--- a/configs/cargo-deny/deny.toml
+++ b/configs/cargo-deny/deny.toml
@@ -13,18 +13,24 @@ allow = [
     "Apache-2.0",
     "BSD-3-Clause",
     "BSL-1.0",
+    "ISC",
     "MIT",
+    "OpenSSL",
     "Unlicense",
     "Zlib",
 ]
 
 exceptions = [
-    { name = "bitmaps", allow = ["MPL-2.0"], version = "*" },
-    { name = "im-rc", allow = ["MPL-2.0"], version = "*" },
-    { name = "sized-chunks", allow = ["MPL-2.0"], version = "*" },
-    { name = "smartstring", allow = ["MPL-2.0"], version = "*" },
+    { name = "webpki-roots", allow = ["MPL-2.0"] },
     { name = "target-lexicon", allow = ["Apache-2.0 WITH LLVM-exception"] },
     { name = "unicode-ident", allow = ["MIT", "Apache-2.0", "Unicode-DFS-2016"] },
+]
+
+[[licenses.clarify]]
+name = "ring"
+expression = "MIT AND ISC AND OpenSSL"
+license-files = [
+    { path = "LICENSE", hash = 0xbd0eed23 },
 ]
 
 [bans]
@@ -33,9 +39,21 @@ multiple-versions = "deny"
 wildcards = "deny"
 
 skip = [
-    # newer version used by cargo
-    # older version used by crypto-hash
-    { name = "hex", version = "0.3.2" },
+    # newer version used by clap_derive
+    # older version used by strum_macros
+    { name = "heck", version = "0.4.1" },
+    # older version used by toml_edit
+    # newer version used by gix-actor
+    { name = "winnow", version = "0.5.40" },
+]
+
+skip-tree = [
+    # windows-sys is not a direct dependency. we skip the
+    # dependency tree because windows-sys has many sub-crates
+    # that differ in major version.
+    { name = "windows-sys" },
+    # redox_syscall is also not a direct dependency.
+    { name = "redox_syscall" },
 ]
 
 [sources]

--- a/configs/cargo-make/deny.toml
+++ b/configs/cargo-make/deny.toml
@@ -1,10 +1,4 @@
 [licenses]
-unlicensed = "deny"
-
-# Deny licenses unless they are specifically listed here
-copyleft = "deny"
-allow-osi-fsf-free = "neither"
-default = "deny"
 
 # We want really high confidence when inferring licenses from text
 confidence-threshold = 0.93

--- a/hashes/cargo-deny
+++ b/hashes/cargo-deny
@@ -1,2 +1,2 @@
-# https://github.com/EmbarkStudios/cargo-deny/archive/0.13.5.tar.gz#/cargo-deny-0.13.5.tar.gz
-SHA512 (cargo-deny-0.13.5.tar.gz) = 76da39d1924c640fa21998415360b6a0e8c1d0661913dd9485fa468897b2763bb74cda4bfe5a3177302de995969d39ddd02ec0a2f897596676186696a042dedf
+# https://github.com/EmbarkStudios/cargo-deny/archive/0.14.20/cargo-deny-0.14.20.tar.gz
+SHA512 (cargo-deny-0.14.20.tar.gz) = 368a18ee5c19760d8477ccdbf8d6fd0b55f574126cbf252bbdbf164576695f1e0b95eabcbaef9c51a9ef3b900abcc15cd8bb6de98152881a12ed653624934338

--- a/hashes/rust
+++ b/hashes/rust
@@ -1,15 +1,15 @@
-# https://static.rust-lang.org/dist/rustc-1.76.0-src.tar.xz
-SHA512 (rustc-1.76.0-src.tar.xz) = 92e16cfdeb91bde341fe6c2774d92868275b07aa1d46d870ddc9291eadfe4ea9af93e06586fa7d6b8d60534903945cbbe706d354c90272712989c58d2bf174bf
-### See https://raw.githubusercontent.com/rust-lang/rust/1.76.0/src/stage0.json for what to use below. ###
-# https://static.rust-lang.org/dist/2023-12-28/rust-std-1.75.0-x86_64-unknown-linux-gnu.tar.xz
-SHA512 (rust-std-1.75.0-x86_64-unknown-linux-gnu.tar.xz) = abf6129f6c4319f0ca1bf741302a8bfde8405f190dacdea72cf57b670b84200d0e67c4ba28a61e2ce23b43c1126fd5cda8716cc80a2ad889a224e7806e37833b
-# https://static.rust-lang.org/dist/2023-12-28/rustc-1.75.0-x86_64-unknown-linux-gnu.tar.xz
-SHA512 (rustc-1.75.0-x86_64-unknown-linux-gnu.tar.xz) = e95c96772242d00bd14018c4461eaf826b6ac301314343e00de07d54d889802e7e14be7187e0496f8a5cc64aed016dc67bfc24efac9948001eb040cee2a3b1b9
-# https://static.rust-lang.org/dist/2023-12-28/cargo-1.75.0-x86_64-unknown-linux-gnu.tar.xz
-SHA512 (cargo-1.75.0-x86_64-unknown-linux-gnu.tar.xz) = bc36976aeab4396cff3214cccfad4445fde55289dbfa1aec3b60596bcb2aa6a44964022ef797013693c7cc07439aabae0fb6300ea2752589b44dc35abc4f3620
-# https://static.rust-lang.org/dist/2023-12-28/rust-std-1.75.0-aarch64-unknown-linux-gnu.tar.xz
-SHA512 (rust-std-1.75.0-aarch64-unknown-linux-gnu.tar.xz) = 0763ae0084dc7aa773a9f53c3786fc32651e5babf5b806979fa690f087d62ac4b8c75af55a5103a69172e043913149b1726c92e8b149b1455451ae26c6db05f0
-# https://static.rust-lang.org/dist/2023-12-28/rustc-1.75.0-aarch64-unknown-linux-gnu.tar.xz
-SHA512 (rustc-1.75.0-aarch64-unknown-linux-gnu.tar.xz) = 1c55e11b800878369344144db1a6d3ab19ec9ed91f31f6b3a2cfc0d42e8f0654a5e3402bd0ce7187de287bda273b64f022c6002f08af7429e31dc401c8d386db
-# https://static.rust-lang.org/dist/2023-12-28/cargo-1.75.0-aarch64-unknown-linux-gnu.tar.xz
-SHA512 (cargo-1.75.0-aarch64-unknown-linux-gnu.tar.xz) = 0014cb8d8053bae9883324a927e8f385d54ebf3b63ba28138d48d30d9102ca4a7966ad54577427e5146ab7767227cb882a80db9f38f46a6a8c4627bc77c52d3b
+# https://static.rust-lang.org/dist/rustc-1.77.0-src.tar.xz
+SHA512 (rustc-1.77.0-src.tar.xz) = 59f19d9def93b613ac72925625e6662622f445506489b8f1cd405d037c28becd53ae1446b46edfd63734f6f236af2dc326a57a184f01bc10d497c96227f09034
+### See https://raw.githubusercontent.com/rust-lang/rust/1.77.0/src/stage0.json for what to use below. ###
+# https://static.rust-lang.org/dist/2024-02-08/rust-std-1.76.0-x86_64-unknown-linux-gnu.tar.xz
+SHA512 (rust-std-1.76.0-x86_64-unknown-linux-gnu.tar.xz) = af6d687a22099acaffe1ca2cd67f585d4f9912cdc2a715b3e3cca538ff01bdae154629b41415d7c99e0c23eb1ab4f8986e59c531fb5be7e1d58979f28d4c91db
+# https://static.rust-lang.org/dist/2024-02-08/rustc-1.76.0-x86_64-unknown-linux-gnu.tar.xz
+SHA512 (rustc-1.76.0-x86_64-unknown-linux-gnu.tar.xz) = 6998cf9943c500caace21596c632c24d280b579ec84248088e9e468a320964a877a22092af2e2d865fc2aea59c12a9d821e2e2a04acb47a828a6ee7bc9ec7cd8
+# https://static.rust-lang.org/dist/2024-02-08/cargo-1.76.0-x86_64-unknown-linux-gnu.tar.xz
+SHA512 (cargo-1.76.0-x86_64-unknown-linux-gnu.tar.xz) = b1998d3d03faa376aa35ef626df2af0f26adeb3d8c8d9dbf35a0fc191c8b7ab78110f5e0ca5d76d0bcb40e44a3ab2a100a52570bc153e5d892d620f30662dc93
+# https://static.rust-lang.org/dist/2024-02-08/rust-std-1.76.0-aarch64-unknown-linux-gnu.tar.xz
+SHA512 (rust-std-1.76.0-aarch64-unknown-linux-gnu.tar.xz) = 485355fab2effcc6b36a40ae544cdcebb671141f28bdb7b7acf8dd2fff33e3faff7791291eeae02328191a77af8d5c8390f0ad0b6b26c844e4a9d6f6504dfd2d
+# https://static.rust-lang.org/dist/2024-02-08/rustc-1.76.0-aarch64-unknown-linux-gnu.tar.xz
+SHA512 (rustc-1.76.0-aarch64-unknown-linux-gnu.tar.xz) = cca205f516248444e76dece9b820925899d078425fcf109190a15a22997184f0c42cce7a99864f4c4f2c4fb823baa7fce6551104a3afee7a7cb7043de714b460
+# https://static.rust-lang.org/dist/2024-02-08/cargo-1.76.0-aarch64-unknown-linux-gnu.tar.xz
+SHA512 (cargo-1.76.0-aarch64-unknown-linux-gnu.tar.xz) = fadd86583bda96b98c5cffbddf2e09f764022786fe594ccb5b913f1cfe762bc322cf0c525fc710470317f54e315ef33aba8844edad356759599ecf5040accbcd

--- a/license-scan/deny.toml
+++ b/license-scan/deny.toml
@@ -1,10 +1,4 @@
 [licenses]
-unlicensed = "deny"
-
-# Deny licenses unless they are specifically listed here
-copyleft = "deny"
-allow-osi-fsf-free = "neither"
-default = "deny"
 
 # We want really high confidence when inferring licenses from text
 confidence-threshold = 0.93

--- a/license-tool/deny.toml
+++ b/license-tool/deny.toml
@@ -1,10 +1,4 @@
 [licenses]
-unlicensed = "deny"
-
-# Deny licenses unless they are specifically listed here
-copyleft = "deny"
-allow-osi-fsf-free = "neither"
-default = "deny"
 
 # We want really high confidence when inferring licenses from text
 confidence-threshold = 0.93

--- a/tools/update-cargo-deny.sh
+++ b/tools/update-cargo-deny.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+
+set -e
+
+if [[ $# -lt 1 ]]; then
+    echo "Usage: $0 $CARGO_DENY_VERSION"
+    echo
+    echo "Example: $0 0.14.20"
+    exit 2
+fi
+
+TOOLSDIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+ROOTDIR=$(realpath "${TOOLSDIR}/..")
+
+VERSION="${1}"
+OUTPUT="${ROOTDIR}/hashes/cargo-deny"
+
+# Get the cargo-deny source package
+# e.g. https://github.com/EmbarkStudios/cargo-deny/archive/0.14.20/cargo-deny-0.14.20.tar.gz
+CARGO_DENY_SRC_PACKAGE="cargo-deny-${VERSION}.tar.gz"
+CARGO_DENY_SRC_URL="https://github.com/EmbarkStudios/cargo-deny/archive/${VERSION}/${CARGO_DENY_SRC_PACKAGE}"
+
+curl -s -L -O -C - "${CARGO_DENY_SRC_URL}"
+
+CARGO_DENY_512_SHA=$(sha512sum "${CARGO_DENY_SRC_PACKAGE}" | cut -d ' ' -f 1)
+
+# Add the root/header information
+echo "# ${CARGO_DENY_SRC_URL}" > "${OUTPUT}"
+echo "SHA512 (${CARGO_DENY_SRC_PACKAGE}) = ${CARGO_DENY_512_SHA}" >> "${OUTPUT}"
+
+DOCKERFILE="${ROOTDIR}/Dockerfile"
+sed -i -e "s,^ENV DENYVER=.*,ENV DENYVER=\"${VERSION}\",g" "${DOCKERFILE}"
+
+echo "================================================"
+echo "cargo-deny updated to ${VERSION}"
+echo "================================================"


### PR DESCRIPTION
**Issue number:**
Fixes: #166


**Description of changes:**
Update Rust to 1.77.0, and cargo-deny to 0.14.20 to get a newer version of `krates`, which was affected by the [package ID format](https://github.com/rust-lang/cargo/blob/master/CHANGELOG.md#added-2) stabilization.


**Testing done:**
`cargo deny` checks in the SDK build passed, after the fixes to `deny.toml` and `clarify.toml` for cargo-deny itself.

Built, launched AMIs for x86_64 and aarch64.


**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
