### PR TITLE
add ORAS and flatc

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -899,6 +899,7 @@ RUN \
     e2fsprogs \
     efitools \
     erofs-utils \
+    flatbuffers-compiler \
     gdisk \
     glibc \
     glib2-devel \

--- a/hashes/oras
+++ b/hashes/oras
@@ -1,0 +1,2 @@
+# https://github.com/oras-project/oras/archive/v1.1.0.tar.gz#/oras-1.1.0.tar.gz
+SHA512 (oras-1.1.0.tar.gz) = 2353a879ca7ff62f2933c2548c3b16e4dafb0b18a6428cb6722121c6961486d821e4caf4d853854cfb5879fcc97338490f6273660ad4235fc9277ad3797071c3


### PR DESCRIPTION
**Issue number:**
N/A


**Description of changes:**
Add the ORAS CLI to support development for Twoliter's kits.

Add the `flatc` compiler which is required to build the SOCI snapshotter.

**Testing done:**
Verified that `oras` and `flatc` are present in the SDK and can be executed..


**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
