### PR TITLE
add hmaccalc

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -964,6 +964,7 @@ RUN \
     kpartx \
     less \
     libcap-devel \
+    libkcapi-hmaccalc \
     lz4 \
     mtools \
     nss-tools \


### PR DESCRIPTION
**Issue number:**
N/A


**Description of changes:**
This will be used to generate an HMAC signature for the kernel, which is required for FIPS. 


**Testing done:**
```
[root@9b687cdc87af builder]# sha512hmac /etc/passwd > /etc/.passwd.hmac
[root@9b687cdc87af builder]# sha512hmac -c /etc/.passwd.hmac
/etc/passwd: OK
```


**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
