### PR TITLE
downgrade Go to 1.21.9

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -443,7 +443,7 @@ RUN \
 
 FROM sdk-libc as sdk-go-prep
 
-ENV GOVER="1.22.1"
+ENV GOVER="1.21.9"
 ENV AWS_LC_FIPS_VER="2.0.9"
 
 USER root

--- a/hashes/go
+++ b/hashes/go
@@ -1,2 +1,2 @@
-# https://go.dev/dl/go1.22.1.src.tar.gz
-SHA512 (go1.22.1.src.tar.gz) = 627530c3fa2ea872478e1df8ee20db2ddc3c94581fff4e66bda21ca45a643e9915f97115401f79667cd7e856ccca1b40a842f4c0b509a472c75696e3bdb3a908
+# https://go.dev/dl/go1.21.9.src.tar.gz
+SHA512 (go1.21.9.src.tar.gz) = e1cf7e458d41f8b343c34b7d35dc4a1696bacbad2ad64abac36dbbeaf1e0a1b71cdb32cebb1686c6e5c90bf0ad3474714d09acea010d6c074730c59d71e79f4e


### PR DESCRIPTION
**Issue number:**
N/A


**Description of changes:**
Downgrade to avoid a known incompatibility with the current version of runc.


**Testing done:**
Launched x86_64 and aarch64 variants and confirmed that containers came up.


**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
