### PR TITLE
Add CA certificates extracted from Mozilla

### DIFF
--- a/configs/ca-certificates/attribution.txt
+++ b/configs/ca-certificates/attribution.txt
@@ -1,0 +1,2 @@
+ca-certificates - https://curl.haxx.se/docs/caextract.html
+SPDX-License-Identifier: MPL-2.0

--- a/hashes/ca-certificates
+++ b/hashes/ca-certificates
@@ -1,0 +1,2 @@
+# https://curl.haxx.se/ca/cacert-2024-03-11.pem
+SHA512 (cacert-2024-03-11.pem) = 31f03cc19566d007c4cffdad2ada71d99b4734ad7b13bc4f30d73d321f40cbe13b87a801aa61d9788207a851cc1f95a8af8ac732a372d45edb932f204bce3744


### PR DESCRIPTION
**Description of changes:**

Include the CA bundle from [bottlerocket:packages/ca-certificates](https://github.com/bottlerocket-os/bottlerocket/tree/3e4f7384f0becb8c49210be646c37ed8be004f73/packages/ca-certificates) in the SDK itself.

**Testing done:**

Built the SDK and verified the new files are in the proper places.

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
