### PR TITLE
gofmt: use the correct path

### DIFF
--- a/wrappers/go/gofmt
+++ b/wrappers/go/gofmt
@@ -7,4 +7,4 @@ shopt -qs failglob
 
 GO_VERSION="${GO_VERSION:?}"
 
-exec /usr/libexec/gofmt-"${GO_VERSION}" "${@}"
+exec /usr/libexec/go-"${GO_VERSION}"/bin/gofmt "${@}"


### PR DESCRIPTION

<!--
Tips:
- Please read the CONTRIBUTING document to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->

**Issue number:**
**Description of changes:**

Fix the path to the gofmt binary for a respective Go version.

**Testing done:**

arm:

```
docker run --rm -it docker.io/library/bottlerocket-sdk:v0.41.0-854dd250-arm64

bash-5.2$ gofmt --help
usage: gofmt [flags] [path ...]
  -cpuprofile string
        write cpu profile to this file
  -d    display diffs instead of rewriting files
  -e    report all errors (not just the first 10 on different lines)
  -l    list files whose formatting differs from gofmt's
  -r string
        rewrite rule (e.g., 'a[b:len(a)] -> a[b:]')
  -s    simplify code
  -w    write result to (source) file instead of stdout
bash-5.2$ 
```

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
