### PR TITLE
macros: enable FIPS check by default

### DIFF
--- a/macros/shared
+++ b/macros/shared
@@ -265,6 +265,9 @@ CROSS_COMPILATION_CONF_EOF\
     --fips-libexecdir="%{_cross_fips_libexecdir}" \
     %{nil}}
 
+# Enable FIPS check by default.
+%cross_check_fips 1
+
 # Generate license attribution and check for FIPS-enabled binaries.
 # (The FIPS check is disabled by default, pending tree-wide packaging changes.)
 %__arch_install_post \


### PR DESCRIPTION
**Issue number:**
Related: https://github.com/bottlerocket-os/bottlerocket/issues/1667


**Description of changes:**
All of the packages in the main repo should now be building binaries for FIPS and non-FIPS. Enable the FIPS check by default so it stays that way.


**Testing done:**
Built the main repo with an SDK build that included this change and confirmed that the FIPS check script was running.
```
❯ rg 'built for FIPS' variants/target/aarch64/debug/build
variants/target/aarch64/debug/build/aws-iam-authenticator-2f7d165b589c418c/output
5350:#20 67.89 Found 1 binary built for FIPS.
```


**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
