### PR TITLE
update Go to 1.21.11 and 1.22.4

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -560,7 +560,7 @@ USER root
 RUN dnf -y install golang
 
 ENV GO121VER="1.21.11"
-ENV GO122VER="1.22.2"
+ENV GO122VER="1.22.4"
 
 # =^..^=   =^..^=   =^..^=   =^..^=   =^..^=   =^..^=   =^..^=   =^..^=   =^..^=
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -559,7 +559,7 @@ ENV AWS_LC_FIPS_VER="2.0.9"
 USER root
 RUN dnf -y install golang
 
-ENV GO121VER="1.21.9"
+ENV GO121VER="1.21.11"
 ENV GO122VER="1.22.2"
 
 # =^..^=   =^..^=   =^..^=   =^..^=   =^..^=   =^..^=   =^..^=   =^..^=   =^..^=

--- a/Dockerfile
+++ b/Dockerfile
@@ -566,7 +566,6 @@ ENV GO122VER="1.22.2"
 
 FROM sdk-go-prep as sdk-go-1.21-prep
 
-ENV GOVER="1.21.9"
 ENV GOMAJOR="1.21"
 
 USER builder
@@ -580,7 +579,7 @@ COPY ./patches/go-${GOMAJOR} /home/builder/patches-go
 COPY ./hashes/aws-lc /home/builder/hashes-aws-lc
 COPY ./patches/aws-lc /home/builder/patches-aws-lc
 
-RUN ./prep-go.sh --go-version=${GOVER} 
+RUN ./prep-go.sh --go-version=${GO121VER}
 
 WORKDIR /home/builder/aws-lc/build
 COPY ./configs/aws-lc/* .
@@ -590,7 +589,6 @@ COPY ./helpers/aws-lc/* .
 
 FROM sdk-go-prep as sdk-go-1.22-prep
 
-ENV GOVER="1.22.2"
 ENV GOMAJOR="1.22"
 
 USER builder
@@ -604,7 +602,7 @@ COPY ./patches/go-${GOMAJOR} /home/builder/patches-go
 COPY ./hashes/aws-lc /home/builder/hashes-aws-lc
 COPY ./patches/aws-lc /home/builder/patches-aws-lc
 
-RUN ./prep-go.sh --go-version=${GOVER}
+RUN ./prep-go.sh --go-version=${GO122VER}
 
 WORKDIR /home/builder/aws-lc/build
 COPY ./configs/aws-lc/* .
@@ -649,7 +647,7 @@ COPY --from=sdk-go-1.21-aws-lc-aarch64 \
 COPY ./helpers/go/* ./
 
 # Build Go - finally!
-RUN ./build-go.sh --go-version=${GOVER}
+RUN ./build-go.sh --go-version=${GO121VER}
 
 # =^..^=   =^..^=   =^..^=   =^..^=   =^..^=   =^..^=   =^..^=   =^..^=   =^..^=
 
@@ -666,7 +664,7 @@ COPY --from=sdk-go-1.22-aws-lc-aarch64 \
 COPY ./helpers/go/* ./
 
 # Build Go - finally!
-RUN ./build-go.sh --go-version=${GOVER}
+RUN ./build-go.sh --go-version=${GO122VER}
 
 # =^..^=   =^..^=   =^..^=   =^..^=   =^..^=   =^..^=   =^..^=   =^..^=   =^..^=
 
@@ -1251,31 +1249,28 @@ COPY --chown=0:0 --from=sdk-rust \
   /usr/share/licenses/rust/
 
 # "sdk-go" has the Go toolchain and standard library builds.
-ENV GOVER="1.21.9"
-COPY --chown=0:0 --from=sdk-go-1.21 /home/builder/sdk-go/bin /usr/libexec/go-${GOVER}/bin/
-COPY --chown=0:0 --from=sdk-go-1.21 /home/builder/sdk-go/lib /usr/libexec/go-${GOVER}/lib/
-COPY --chown=0:0 --from=sdk-go-1.21 /home/builder/sdk-go/pkg /usr/libexec/go-${GOVER}/pkg/
-COPY --chown=0:0 --from=sdk-go-1.21 /home/builder/sdk-go/src /usr/libexec/go-${GOVER}/src/
-COPY --chown=0:0 --from=sdk-go-1.21 /home/builder/sdk-go/go.env /usr/libexec/go-${GOVER}/go.env
+COPY --chown=0:0 --from=sdk-go-1.21 /home/builder/sdk-go/bin /usr/libexec/go-1.21/bin/
+COPY --chown=0:0 --from=sdk-go-1.21 /home/builder/sdk-go/lib /usr/libexec/go-1.21/lib/
+COPY --chown=0:0 --from=sdk-go-1.21 /home/builder/sdk-go/pkg /usr/libexec/go-1.21/pkg/
+COPY --chown=0:0 --from=sdk-go-1.21 /home/builder/sdk-go/src /usr/libexec/go-1.21/src/
+COPY --chown=0:0 --from=sdk-go-1.21 /home/builder/sdk-go/go.env /usr/libexec/go-1.21/go.env
 COPY --chown=0:0 --from=sdk-go-1.21 \
   /home/builder/sdk-go/licenses/ \
-  /usr/share/licenses/go-${GOVER}/
+  /usr/share/licenses/go-1.21/
 
 COPY --chown=0:0 --from=sdk-go-1.21 \
   /home/builder/aws-lc/LICENSE \
   /usr/share/licenses/aws-lc/LICENSE
 
-
-ENV GOVER="1.22.2"
-COPY --chown=0:0 --from=sdk-go-1.22 /home/builder/sdk-go/bin /usr/libexec/go-${GOVER}/bin/
-COPY --chown=0:0 --from=sdk-go-1.22 /home/builder/sdk-go/lib /usr/libexec/go-${GOVER}/lib/
-COPY --chown=0:0 --from=sdk-go-1.22 /home/builder/sdk-go/pkg /usr/libexec/go-${GOVER}/pkg/
-COPY --chown=0:0 --from=sdk-go-1.22 /home/builder/sdk-go/src /usr/libexec/go-${GOVER}/src/
-COPY --chown=0:0 --from=sdk-go-1.22 /home/builder/sdk-go/go.env /usr/libexec/go-${GOVER}/go.env
+COPY --chown=0:0 --from=sdk-go-1.22 /home/builder/sdk-go/bin /usr/libexec/go-1.22/bin/
+COPY --chown=0:0 --from=sdk-go-1.22 /home/builder/sdk-go/lib /usr/libexec/go-1.22/lib/
+COPY --chown=0:0 --from=sdk-go-1.22 /home/builder/sdk-go/pkg /usr/libexec/go-1.22/pkg/
+COPY --chown=0:0 --from=sdk-go-1.22 /home/builder/sdk-go/src /usr/libexec/go-1.22/src/
+COPY --chown=0:0 --from=sdk-go-1.22 /home/builder/sdk-go/go.env /usr/libexec/go-1.22/go.env
 
 COPY --chown=0:0 --from=sdk-go-1.22 \
   /home/builder/sdk-go/licenses/ \
-  /usr/share/licenses/go-${GOVER}/
+  /usr/share/licenses/go-1.22/
 
 # "sdk-rust-tools" has our attribution generation and license scan tools.
 COPY --chown=0:0 --from=sdk-rust-tools /usr/libexec/tools/ /usr/libexec/tools/
@@ -1390,11 +1385,9 @@ COPY ./wrappers/go/gofmt /usr/bin/gofmt
 COPY ./wrappers/go/gofips /usr/bin/gofips
 
 # Add Go programs to $PATH and sync timestamps to avoid rebuilds.
-ENV GO121VER="1.21.9"
-ENV GO122VER="1.22.2"
 RUN \
-  find /usr/libexec/go-${GO121VER} -type f -exec touch -r /usr/libexec/go-${GO121VER}/bin/go {} \+ && \
-  find /usr/libexec/go-${GO122VER} -type f -exec touch -r /usr/libexec/go-${GO122VER}/bin/go {} \+
+  find /usr/libexec/go-1.21 -type f -exec touch -r /usr/libexec/go-1.21/bin/go {} \+ && \
+  find /usr/libexec/go-1.22 -type f -exec touch -r /usr/libexec/go-1.22/bin/go {} \+
 
 # Strip and add tools to the path.
 RUN \
@@ -1443,6 +1436,7 @@ COPY --from=sdk-final / /
 USER builder
 WORKDIR /home/builder
 
-ENV GO_VERSION="1.21.9"
+# Set the default Go major version.
+ENV GO_MAJOR="1.21"
 
 CMD ["/bin/bash"]

--- a/hashes/go-1.21
+++ b/hashes/go-1.21
@@ -1,2 +1,2 @@
-# https://go.dev/dl/go1.21.9.src.tar.gz
-SHA512 (go1.21.9.src.tar.gz) = e1cf7e458d41f8b343c34b7d35dc4a1696bacbad2ad64abac36dbbeaf1e0a1b71cdb32cebb1686c6e5c90bf0ad3474714d09acea010d6c074730c59d71e79f4e
+# https://go.dev/dl/go1.21.11.src.tar.gz
+SHA512 (go1.21.11.src.tar.gz) = dffcef964a4fbe08cd965bcffad6138fab164f14936a83988ced86924f794c1f107c122d1aeb674eacb0a1a498a31bdf83ea8f87b352494fa69f6e38931d2120

--- a/hashes/go-1.22
+++ b/hashes/go-1.22
@@ -1,2 +1,2 @@
-# https://go.dev/dl/go1.22.2.src.tar.gz
-SHA512 (go1.22.2.src.tar.gz) = f2491d2b5d4ef2dd86ca7820503a2534cd1860822049dc01a6cb40b556a0812cfc4196fa83173765816060253ac949f4165b0fb4b2bed5d45e30d03bb69e434d
+# https://go.dev/dl/go1.22.4.src.tar.gz
+SHA512 (go1.22.4.src.tar.gz) = 4855ba7e277b2eb79eb52e3ad2a52f18b3a4cd3adc20b7a17d29fabae74141265bf31399307b8d3f35110031d11ad7f583016aa903f3e36eeb6d1f64cfc8a5ad

--- a/tools/update-go.sh
+++ b/tools/update-go.sh
@@ -13,7 +13,10 @@ TOOLSDIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 ROOTDIR=$(realpath "${TOOLSDIR}/..")
 
 VERSION="${1}"
-OUTPUT="${ROOTDIR}/hashes/go"
+GOMAJOR="${VERSION%.*}"
+GOVER="${GOMAJOR//./}"
+
+OUTPUT="${ROOTDIR}/hashes/go-${GOMAJOR}"
 PACKAGE_ROOT="https://go.dev/dl"
 
 # Get the go source package
@@ -21,6 +24,7 @@ PACKAGE_ROOT="https://go.dev/dl"
 GO_SRC_PACKAGE="go${VERSION}.src.tar.gz"
 GO_SRC_URL="${PACKAGE_ROOT}/${GO_SRC_PACKAGE}"
 
+rm -f "${GO_SRC_PACKAGE}"
 curl -s -L -O -C - "${GO_SRC_URL}"
 
 # SHA256 is only used to validate the package with the published checksum
@@ -46,8 +50,8 @@ echo "# ${GO_SRC_URL}" > "${OUTPUT}"
 echo "SHA512 (${GO_SRC_PACKAGE}) = ${GO_512_SHA}" >> "${OUTPUT}"
 
 DOCKERFILE="${ROOTDIR}/Dockerfile"
-sed -i -e "s,^ENV GOVER=.*,ENV GOVER=\"${VERSION}\",g" "${DOCKERFILE}"
+sed -i -e "s,^ENV GO${GOVER}VER=.*,ENV GO${GOVER}VER=\"${VERSION}\",g" "${DOCKERFILE}"
 
 echo "================================================"
-echo "go toolchain updated to ${VERSION}"
+echo "go-${GOMAJOR} toolchain updated to ${VERSION}"
 echo "================================================"

--- a/wrappers/go/go
+++ b/wrappers/go/go
@@ -1,10 +1,13 @@
 #!/usr/bin/env bash
 
-# wrapper script to run a specific version of Go
+# wrapper script to run a specific major release of Go
 
 set -eu -o pipefail
 shopt -qs failglob
 
-GO_VERSION="${GO_VERSION:?}"
+# prefer GO_VERSION over GO_MAJOR if present, to preserve original behavior
+if [ -n "${GO_VERSION:-}" ] ; then
+  GO_MAJOR="${GO_VERSION%.*}"
+fi
 
-exec /usr/libexec/go-"${GO_VERSION}"/bin/go "${@}"
+exec /usr/libexec/go-"${GO_MAJOR}"/bin/go "${@}"

--- a/wrappers/go/gofips
+++ b/wrappers/go/gofips
@@ -5,7 +5,10 @@
 set -eu -o pipefail
 shopt -qs failglob
 
-GO_VERSION="${GO_VERSION:?}"
+# prefer GO_VERSION over GO_MAJOR if present, to preserve original behavior
+if [ -n "${GO_VERSION:-}" ] ; then
+  GO_MAJOR="${GO_VERSION%.*}"
+fi
 
 export GOEXPERIMENT=boringcrypto
-exec /usr/libexec/go-"${GO_VERSION}"/bin/go "${@}"
+exec /usr/libexec/go-"${GO_MAJOR}"/bin/go "${@}"

--- a/wrappers/go/gofmt
+++ b/wrappers/go/gofmt
@@ -5,6 +5,9 @@
 set -eu -o pipefail
 shopt -qs failglob
 
-GO_VERSION="${GO_VERSION:?}"
+# prefer GO_VERSION over GO_MAJOR if present, to preserve original behavior
+if [ -n "${GO_VERSION:-}" ] ; then
+  GO_MAJOR="${GO_VERSION%.*}"
+fi
 
-exec /usr/libexec/go-"${GO_VERSION}"/bin/gofmt "${@}"
+exec /usr/libexec/go-"${GO_MAJOR}"/bin/gofmt "${@}"


### PR DESCRIPTION
**Issue number:**
N/A


**Description of changes:**
Update Go to 1.21.11 and 1.22.4.


**Testing done:**
Built the SDK, and built variants for both target architectures on both host architectures - including aws-k8s-1.30, which needs Go 1.22.4.


**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
