### PR TITLE
add libbpf-devel

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1063,6 +1063,7 @@ RUN \
     groff \
     kpartx \
     less \
+    libbpf-devel \
     libcap-devel \
     libkcapi-hmaccalc \
     lz4 \


### PR DESCRIPTION


<!--
Tips:
- Please read the CONTRIBUTING document to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->

**Issue number:**
N/A


**Description of changes:**
this makes it possible to compile bpf programs using clang that require the `bpf` target

**Testing done:**
Built the SDK


**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
