### PR TITLE
replace Fedora's `lz4` with upstream binaries

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1065,7 +1065,6 @@ RUN \
     less \
     libcap-devel \
     libkcapi-hmaccalc \
-    lz4 \
     mtools \
     nss-tools \
     openssl-pkcs11 \
@@ -1107,6 +1106,28 @@ RUN \
   install -p -m 0644 -D -t \
     /usr/share/licenses/awscli-${AWSCLI_VER} \
     aws/THIRD_PARTY_LICENSES && \
+  rm -rf /home/builder
+
+# =^..^=   =^..^=   =^..^=   =^..^=   =^..^=   =^..^=   =^..^=   =^..^=   =^..^=
+FROM sdk-plus as sdk-plus-lz4
+
+ENV LZ4_VER="1.10.0"
+
+USER builder
+WORKDIR /home/builder/lz4
+COPY ./hashes/lz4 ./hashes
+RUN \
+  sdk-fetch hashes && \
+  tar --strip-components=1 -xf lz4-${LZ4_VER}.tar.gz && \
+  rm lz4-${LZ4_VER}.tar.gz
+RUN make
+
+USER root
+RUN \
+  make install && \
+  install -p -m 0644 -D -t \
+    /usr/share/licenses/lz4 \
+    programs/COPYING && \
   rm -rf /home/builder
 
 # =^..^=   =^..^=   =^..^=   =^..^=   =^..^=   =^..^=   =^..^=   =^..^=   =^..^=
@@ -1197,6 +1218,8 @@ WORKDIR /
 # "sdk-plus" has our C/C++ toolchain and kernel headers for both targets, and
 # any other host programs we want available for OS builds.
 COPY --from=sdk-plus / /
+COPY --from=sdk-plus-lz4 /usr/local /usr/local
+COPY --from=sdk-plus-lz4 /usr/share/licenses/lz4 /usr/share/licenses/lz4
 
 # "toolchain-archive" has the toolchains for both targets bundled together in
 # a format that's convenient for extracting later.

--- a/hashes/lz4
+++ b/hashes/lz4
@@ -1,0 +1,2 @@
+# https://github.com/lz4/lz4/releases/download/v1.10.0/lz4-1.10.0.tar.gz
+SHA512 (lz4-1.10.0.tar.gz) = 8c4ceb217e6dc8e7e0beba99adc736aca8963867bcf9f970d621978ba11ce92855912f8b66138037a1d2ae171e8e17beb7be99281fea840106aa60373c455b28


### PR DESCRIPTION
**Issue number:**

#195

**Description of changes:**

LZ4 v1.10.0 is a major update that brings (among other things) multithreading support.

**Testing done:**

Repacked Bottlerocket 1.20.x (went from ~77.84s to ~49.68s 🚀)

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
