### PR TITLE
update cargo-deny to 0.16.1

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -707,7 +707,7 @@ RUN cargo build --release --locked
 
 FROM sdk-cargo as sdk-cargo-deny
 
-ENV DENYVER="0.14.20"
+ENV DENYVER="0.16.1"
 
 USER builder
 WORKDIR /home/builder

--- a/configs/cargo-deny/clarify.toml
+++ b/configs/cargo-deny/clarify.toml
@@ -131,6 +131,17 @@ license-files = [
     { path = "LICENSE-THIRD-PARTY", hash = 0xcf4d856 },
 ]
 
+[clarify.petgraph]
+expression = "MIT OR Apache-2.0"
+license-files = [
+    { path = "LICENSE-APACHE", hash = 0x24b54f4b },
+    { path = "LICENSE-MIT", hash = 0xc97e30bd },
+]
+# we aren't distributing graphical assets
+skip-files = [
+    "assets/LICENSE.md"
+]
+
 [clarify.regex]
 expression = "MIT OR Apache-2.0"
 license-files = [
@@ -166,6 +177,12 @@ skip-files = [
     "src/advisory/license.rs",
 ]
 
+[clarify.sha1_smol]
+expression = "BSD-3-Clause AND Apache-2.0"
+license-files = [
+    { path = "LICENSE", hash = 0xcfa59836 },
+]
+
 [clarify.spdx]
 expression = "MIT OR Apache-2.0"
 license-files = [
@@ -187,6 +204,7 @@ skip-files = [
     "src/text/licenses/AGPL-3.0-or-later",
     "src/text/licenses/BSD-1-Clause",
     "src/text/licenses/BSD-2-Clause",
+    "src/text/licenses/BSD-2-Clause-first-lines",
     "src/text/licenses/BSD-2-Clause-Darwin",
     "src/text/licenses/BSD-2-Clause-FreeBSD",
     "src/text/licenses/BSD-2-Clause-NetBSD",

--- a/hashes/cargo-deny
+++ b/hashes/cargo-deny
@@ -1,2 +1,2 @@
-# https://github.com/EmbarkStudios/cargo-deny/archive/0.14.20/cargo-deny-0.14.20.tar.gz
-SHA512 (cargo-deny-0.14.20.tar.gz) = 368a18ee5c19760d8477ccdbf8d6fd0b55f574126cbf252bbdbf164576695f1e0b95eabcbaef9c51a9ef3b900abcc15cd8bb6de98152881a12ed653624934338
+# https://github.com/EmbarkStudios/cargo-deny/archive/0.16.1/cargo-deny-0.16.1.tar.gz
+SHA512 (cargo-deny-0.16.1.tar.gz) = 3801dda508b64cb94ea2b265f52220760f66075396ae3771bcb09e24389d595c2bd29a1f3d3a833e117b663526859e99c14763eb4b8ca75490b6470b5fb3b193


### PR DESCRIPTION
**Description of changes:**
This updates to the latest version of `cargo-deny`.

**Testing done:**
* Built new SDK and ran `make twoliter check-licenses` in the bottlerocket-core-kit
* Enabled new "workspace-dependencies" features in core-kit deny.toml and noted that cargo deny behaved correctly.

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
