### PR TITLE
go: remove `GOROOT_FINAL`

### DIFF
--- a/helpers/go/build-go.sh
+++ b/helpers/go/build-go.sh
@@ -12,12 +12,12 @@ done
 
 GOVER="${GOVER:?}"
 
-export GOROOT_FINAL="/usr/libexec/go-${GOVER}"
 cd "${HOME}/sdk-go/src"
 ./all.bash
 
 # Install the Go standard library and toolchain.
 cd "${HOME}/sdk-go"
+# shellcheck disable=SC2034
 PATH="${HOME}/sdk-go/bin:${PATH}" GO111MODULE="auto"
 go install -buildmode=pie std cmd
 install -p -m 0644 -Dt licenses LICENSE PATENTS


### PR DESCRIPTION
<!--
Tips:
- Please read the CONTRIBUTING document to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->

**Issue number:**

Closes: #200 

**Description of changes:**

`GOROOT_FINAL` is not supported in Go 1.23. the bottlerocket-sdk wasn't using it anyway :) In the sdk-final stage of the Dockerfile, the Go sources and build artifacts for respective versions are copied over directly from `/home/builder/sdk-go directory` in a Go version layer's respective directory:

https://github.com/bottlerocket-os/bottlerocket-sdk/blob/6b0525c30cd510713d4a18de484370844dfbc1c9/Dockerfile#L1239-L1261


This commit also disables a shellcheck warning that thinks `GO111MODULE` is unused in `helpers/go/build-go.sh`

**Testing done:**


```
$ make
$ docker run --rm bottlerocket-sdk:v0.43.0-cec1e119-arm64 ls /usr/libexec | grep go
go-1.22
go-1.23
$ docker run --rm -e GO_MAJOR=1.23 bottlerocket-sdk:v0.43.0-cec1e119-arm64 go version
go version go1.23.0 linux/arm64
$ docker run --rm -e GO_MAJOR=1.22 bottlerocket-sdk:v0.43.0-cec1e119-arm64 go version
go version go1.22.6 linux/arm64
```

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
