### PR TITLE
ca-certificates: ingest latest upstream

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -524,7 +524,7 @@ FROM sdk as sdk-ca-certificates
 
 USER root
 
-ENV CABUNDLEVER="2024-03-11"
+ENV CABUNDLEVER="2024-07-02"
 
 RUN \
   mkdir -p /usr/share/bottlerocket/ca-certificates && \

--- a/configs/ca-certificates/attribution.txt
+++ b/configs/ca-certificates/attribution.txt
@@ -1,2 +1,2 @@
-ca-certificates - https://curl.haxx.se/docs/caextract.html
+ca-certificates - https://curl.se/docs/caextract.html
 SPDX-License-Identifier: MPL-2.0

--- a/hashes/ca-certificates
+++ b/hashes/ca-certificates
@@ -1,2 +1,2 @@
-# https://curl.haxx.se/ca/cacert-2024-03-11.pem
-SHA512 (cacert-2024-03-11.pem) = 31f03cc19566d007c4cffdad2ada71d99b4734ad7b13bc4f30d73d321f40cbe13b87a801aa61d9788207a851cc1f95a8af8ac732a372d45edb932f204bce3744
+# https://curl.se/ca/cacert-2024-07-02.pem
+SHA512 (cacert-2024-07-02.pem) = 6c8d96ebedaacaafd3997fb2c5dca7537f64121005efc7084aa97a950e4a53eac1fd640cfe8335e1e32b16253fc7306132f2cefaa588891042653bdaf36ff6c7


### PR DESCRIPTION
**Description of changes:**

Our upstream changed URLs and released a new bundle on July 3.

**Testing done:**

Built SDK image locally.

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
