### PR TITLE
update Rust to 1.81.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -339,7 +339,7 @@ RUN \
 
 ARG HOST_ARCH
 ENV VENDOR="bottlerocket"
-ENV RUSTVER="1.80.1"
+ENV RUSTVER="1.81.0"
 
 USER builder
 WORKDIR /home/builder

--- a/Dockerfile
+++ b/Dockerfile
@@ -339,7 +339,7 @@ RUN \
 
 ARG HOST_ARCH
 ENV VENDOR="bottlerocket"
-ENV RUSTVER="1.79.0"
+ENV RUSTVER="1.80.1"
 
 USER builder
 WORKDIR /home/builder
@@ -352,7 +352,7 @@ RUN \
 
 WORKDIR /home/builder/rust
 RUN \
-  dir=build/cache/$(jq -r '.compiler.date' src/stage0.json); \
+  dir=build/cache/$(awk -F= '/^compiler_date/{print $2}' src/stage0); \
   mkdir -p $dir && mv ../*.xz $dir
 
 # For any architecture, we rely on two or more of Rust's native targets:
@@ -378,34 +378,22 @@ RUN \
 # To resolve this, we create vendor-specific targets based on the native ones.
 # That allows us to leave the settings for the host platform alone, while also
 # ensuring that the target platform always uses the libraries from our sysroot.
-# These vendor targets are effectively the same as the "unknown" targets, so we
-# just need to copy them, change the "vendor" field, and refer to them in the
-# module so `rustc` knows they exist.
-
-RUN \
-  for arch in x86_64 aarch64 ; do \
-    for libc in gnu musl ; do \
-      cp compiler/rustc_target/src/spec/targets/${arch}_{unknown,${VENDOR}}_linux_${libc}.rs && \
-      sed -i -e '/let mut base = base::linux_'${libc}'::opts();/a base.vendor = "'${VENDOR}'".into();' \
-        compiler/rustc_target/src/spec/targets/${arch}_${VENDOR}_linux_${libc}.rs && \
-      sed -i -e '/ \.\.base::linux_'${libc}'::opts()/i vendor: "'${VENDOR}'".into(),' \
-        compiler/rustc_target/src/spec/targets/${arch}_${VENDOR}_linux_${libc}.rs && \
-      sed -i -e '/("'${arch}-unknown-linux-${libc}'", .*),/a("'${arch}-${VENDOR}-linux-${libc}'", '${arch}_${VENDOR}_linux_${libc}'),' \
-        compiler/rustc_target/src/spec/mod.rs ; \
-    done ; \
-  done && \
-  grep -Fq ${VENDOR} compiler/rustc_target/src/spec/mod.rs && \
-  grep -Fq ${VENDOR} compiler/rustc_target/src/spec/targets/x86_64_${VENDOR}_linux_gnu.rs && \
-  grep -Fq ${VENDOR} compiler/rustc_target/src/spec/targets/x86_64_${VENDOR}_linux_musl.rs && \
-  grep -Fq ${VENDOR} compiler/rustc_target/src/spec/targets/aarch64_${VENDOR}_linux_gnu.rs && \
-  grep -Fq ${VENDOR} compiler/rustc_target/src/spec/targets/aarch64_${VENDOR}_linux_musl.rs
+# These vendor targets are effectively the same as the "unknown" targets.
+COPY ./configs/rust/targets ./targets
 
 # In addition to our vendor-specific targets, we also need to build for the host
 # platform, since that is no longer done implicitly.
-COPY ./configs/rust/* ./
+COPY ./configs/rust/config.toml.in ./
 RUN \
   sed -e "s,@HOST_TRIPLE@,${HOST_ARCH}-unknown-linux-gnu,g" config.toml.in > config.toml && \
-  RUSTUP_DIST_SERVER=example:// python3 ./x.py install
+  RUSTUP_DIST_SERVER=example:// RUST_TARGET_PATH=${PWD}/targets python3 ./x.py install && \
+  for arch in x86_64 aarch64 ; do \
+    for libc in gnu musl ; do \
+      cp \
+        targets/${arch}-bottlerocket-linux-${libc}.json \
+        /usr/libexec/rust/lib/rustlib/${arch}-bottlerocket-linux-${libc}/target.json ; \
+    done ; \
+  done
 
 RUN \
   install -p -m 0644 -Dt licenses COPYRIGHT LICENSE-*

--- a/configs/rust/config.toml.in
+++ b/configs/rust/config.toml.in
@@ -1,5 +1,6 @@
 # See the example config for more details on these settings:
-# https://github.com/rust-lang/rust/blob/master/config.toml.example
+# https://github.com/rust-lang/rust/blob/master/config.example.toml
+change-id = 125535
 
 [build]
 target = [

--- a/configs/rust/targets/aarch64-bottlerocket-linux-gnu.json
+++ b/configs/rust/targets/aarch64-bottlerocket-linux-gnu.json
@@ -13,10 +13,10 @@
   "llvm-target": "aarch64-unknown-linux-gnu",
   "max-atomic-width": 128,
   "metadata": {
-    "description": null,
-    "host_tools": null,
-    "std": null,
-    "tier": null
+    "description": "ARM64 Linux (kernel 4.1, glibc 2.17+)",
+    "host_tools": true,
+    "std": true,
+    "tier": 1
   },
   "os": "linux",
   "position-independent-executables": true,

--- a/configs/rust/targets/aarch64-bottlerocket-linux-gnu.json
+++ b/configs/rust/targets/aarch64-bottlerocket-linux-gnu.json
@@ -1,0 +1,49 @@
+{
+  "arch": "aarch64",
+  "crt-objects-fallback": "false",
+  "crt-static-respected": true,
+  "data-layout": "e-m:e-i8:8:32-i16:16:32-i64:64-i128:128-n32:64-S128-Fn32",
+  "dynamic-linking": true,
+  "env": "gnu",
+  "features": "+v8a,+outline-atomics",
+  "has-rpath": true,
+  "has-thread-local": true,
+  "is-builtin": false,
+  "linker-flavor": "gnu-cc",
+  "llvm-target": "aarch64-unknown-linux-gnu",
+  "max-atomic-width": 128,
+  "metadata": {
+    "description": null,
+    "host_tools": null,
+    "std": null,
+    "tier": null
+  },
+  "os": "linux",
+  "position-independent-executables": true,
+  "relro-level": "full",
+  "stack-probes": {
+    "kind": "inline"
+  },
+  "supported-sanitizers": [
+    "address",
+    "leak",
+    "memory",
+    "thread",
+    "hwaddress",
+    "cfi",
+    "memtag",
+    "kcfi"
+  ],
+  "supported-split-debuginfo": [
+    "packed",
+    "unpacked",
+    "off"
+  ],
+  "supports-xray": true,
+  "target-family": [
+    "unix"
+  ],
+  "target-mcount": "\u0001_mcount",
+  "target-pointer-width": "64",
+  "vendor": "bottlerocket"
+}

--- a/configs/rust/targets/aarch64-bottlerocket-linux-musl.json
+++ b/configs/rust/targets/aarch64-bottlerocket-linux-musl.json
@@ -14,10 +14,10 @@
   "llvm-target": "aarch64-unknown-linux-musl",
   "max-atomic-width": 128,
   "metadata": {
-    "description": null,
-    "host_tools": null,
-    "std": null,
-    "tier": null
+    "description": "ARM64 Linux with musl 1.2.3",
+    "host_tools": true,
+    "std": true,
+    "tier": 2
   },
   "os": "linux",
   "position-independent-executables": true,

--- a/configs/rust/targets/aarch64-bottlerocket-linux-musl.json
+++ b/configs/rust/targets/aarch64-bottlerocket-linux-musl.json
@@ -1,0 +1,103 @@
+{
+  "arch": "aarch64",
+  "crt-objects-fallback": "musl",
+  "crt-static-default": true,
+  "crt-static-respected": true,
+  "data-layout": "e-m:e-i8:8:32-i16:16:32-i64:64-i128:128-n32:64-S128-Fn32",
+  "dynamic-linking": true,
+  "env": "musl",
+  "features": "+v8a",
+  "has-rpath": true,
+  "has-thread-local": true,
+  "is-builtin": false,
+  "linker-flavor": "gnu-cc",
+  "llvm-target": "aarch64-unknown-linux-musl",
+  "max-atomic-width": 128,
+  "metadata": {
+    "description": null,
+    "host_tools": null,
+    "std": null,
+    "tier": null
+  },
+  "os": "linux",
+  "position-independent-executables": true,
+  "post-link-objects-fallback": {
+    "dynamic-dylib": [
+      "crtendS.o",
+      "crtn.o"
+    ],
+    "dynamic-nopic-exe": [
+      "crtend.o",
+      "crtn.o"
+    ],
+    "dynamic-pic-exe": [
+      "crtendS.o",
+      "crtn.o"
+    ],
+    "static-dylib": [
+      "crtendS.o",
+      "crtn.o"
+    ],
+    "static-nopic-exe": [
+      "crtend.o",
+      "crtn.o"
+    ],
+    "static-pic-exe": [
+      "crtendS.o",
+      "crtn.o"
+    ]
+  },
+  "pre-link-objects-fallback": {
+    "dynamic-dylib": [
+      "crti.o",
+      "crtbeginS.o"
+    ],
+    "dynamic-nopic-exe": [
+      "crt1.o",
+      "crti.o",
+      "crtbegin.o"
+    ],
+    "dynamic-pic-exe": [
+      "Scrt1.o",
+      "crti.o",
+      "crtbeginS.o"
+    ],
+    "static-dylib": [
+      "crti.o",
+      "crtbeginS.o"
+    ],
+    "static-nopic-exe": [
+      "crt1.o",
+      "crti.o",
+      "crtbegin.o"
+    ],
+    "static-pic-exe": [
+      "rcrt1.o",
+      "crti.o",
+      "crtbeginS.o"
+    ]
+  },
+  "relro-level": "full",
+  "stack-probes": {
+    "kind": "inline"
+  },
+  "supported-sanitizers": [
+    "address",
+    "leak",
+    "memory",
+    "thread",
+    "cfi"
+  ],
+  "supported-split-debuginfo": [
+    "packed",
+    "unpacked",
+    "off"
+  ],
+  "supports-xray": true,
+  "target-family": [
+    "unix"
+  ],
+  "target-mcount": "\u0001_mcount",
+  "target-pointer-width": "64",
+  "vendor": "bottlerocket"
+}

--- a/configs/rust/targets/x86_64-bottlerocket-linux-gnu.json
+++ b/configs/rust/targets/x86_64-bottlerocket-linux-gnu.json
@@ -13,10 +13,10 @@
   "llvm-target": "x86_64-unknown-linux-gnu",
   "max-atomic-width": 64,
   "metadata": {
-    "description": null,
-    "host_tools": null,
-    "std": null,
-    "tier": null
+    "description": "64-bit Linux (kernel 3.2+, glibc 2.17+)",
+    "host_tools": true,
+    "std": true,
+    "tier": 1
   },
   "os": "linux",
   "plt-by-default": false,

--- a/configs/rust/targets/x86_64-bottlerocket-linux-gnu.json
+++ b/configs/rust/targets/x86_64-bottlerocket-linux-gnu.json
@@ -1,0 +1,58 @@
+{
+  "arch": "x86_64",
+  "cpu": "x86-64",
+  "crt-objects-fallback": "false",
+  "crt-static-respected": true,
+  "data-layout": "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-i128:128-f80:128-n8:16:32:64-S128",
+  "dynamic-linking": true,
+  "env": "gnu",
+  "has-rpath": true,
+  "has-thread-local": true,
+  "is-builtin": false,
+  "linker-flavor": "gnu-cc",
+  "llvm-target": "x86_64-unknown-linux-gnu",
+  "max-atomic-width": 64,
+  "metadata": {
+    "description": null,
+    "host_tools": null,
+    "std": null,
+    "tier": null
+  },
+  "os": "linux",
+  "plt-by-default": false,
+  "position-independent-executables": true,
+  "pre-link-args": {
+    "gnu-cc": [
+      "-m64"
+    ],
+    "gnu-lld-cc": [
+      "-m64"
+    ]
+  },
+  "relro-level": "full",
+  "stack-probes": {
+    "kind": "inline"
+  },
+  "static-position-independent-executables": true,
+  "supported-sanitizers": [
+    "address",
+    "leak",
+    "memory",
+    "thread",
+    "cfi",
+    "kcfi",
+    "safestack",
+    "dataflow"
+  ],
+  "supported-split-debuginfo": [
+    "packed",
+    "unpacked",
+    "off"
+  ],
+  "supports-xray": true,
+  "target-family": [
+    "unix"
+  ],
+  "target-pointer-width": "64",
+  "vendor": "bottlerocket"
+}

--- a/configs/rust/targets/x86_64-bottlerocket-linux-musl.json
+++ b/configs/rust/targets/x86_64-bottlerocket-linux-musl.json
@@ -1,0 +1,112 @@
+{
+  "arch": "x86_64",
+  "cpu": "x86-64",
+  "crt-objects-fallback": "musl",
+  "crt-static-default": true,
+  "crt-static-respected": true,
+  "data-layout": "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-i128:128-f80:128-n8:16:32:64-S128",
+  "dynamic-linking": true,
+  "env": "musl",
+  "has-rpath": true,
+  "has-thread-local": true,
+  "is-builtin": false,
+  "linker-flavor": "gnu-cc",
+  "llvm-target": "x86_64-unknown-linux-musl",
+  "max-atomic-width": 64,
+  "metadata": {
+    "description": null,
+    "host_tools": null,
+    "std": null,
+    "tier": null
+  },
+  "os": "linux",
+  "plt-by-default": false,
+  "position-independent-executables": true,
+  "post-link-objects-fallback": {
+    "dynamic-dylib": [
+      "crtendS.o",
+      "crtn.o"
+    ],
+    "dynamic-nopic-exe": [
+      "crtend.o",
+      "crtn.o"
+    ],
+    "dynamic-pic-exe": [
+      "crtendS.o",
+      "crtn.o"
+    ],
+    "static-dylib": [
+      "crtendS.o",
+      "crtn.o"
+    ],
+    "static-nopic-exe": [
+      "crtend.o",
+      "crtn.o"
+    ],
+    "static-pic-exe": [
+      "crtendS.o",
+      "crtn.o"
+    ]
+  },
+  "pre-link-args": {
+    "gnu-cc": [
+      "-m64"
+    ],
+    "gnu-lld-cc": [
+      "-m64"
+    ]
+  },
+  "pre-link-objects-fallback": {
+    "dynamic-dylib": [
+      "crti.o",
+      "crtbeginS.o"
+    ],
+    "dynamic-nopic-exe": [
+      "crt1.o",
+      "crti.o",
+      "crtbegin.o"
+    ],
+    "dynamic-pic-exe": [
+      "Scrt1.o",
+      "crti.o",
+      "crtbeginS.o"
+    ],
+    "static-dylib": [
+      "crti.o",
+      "crtbeginS.o"
+    ],
+    "static-nopic-exe": [
+      "crt1.o",
+      "crti.o",
+      "crtbegin.o"
+    ],
+    "static-pic-exe": [
+      "rcrt1.o",
+      "crti.o",
+      "crtbeginS.o"
+    ]
+  },
+  "relro-level": "full",
+  "stack-probes": {
+    "kind": "inline"
+  },
+  "static-position-independent-executables": true,
+  "supported-sanitizers": [
+    "address",
+    "leak",
+    "memory",
+    "thread",
+    "cfi"
+  ],
+  "supported-split-debuginfo": [
+    "packed",
+    "unpacked",
+    "off"
+  ],
+  "supports-xray": true,
+  "target-family": [
+    "unix"
+  ],
+  "target-pointer-width": "64",
+  "vendor": "bottlerocket"
+}

--- a/configs/rust/targets/x86_64-bottlerocket-linux-musl.json
+++ b/configs/rust/targets/x86_64-bottlerocket-linux-musl.json
@@ -14,10 +14,10 @@
   "llvm-target": "x86_64-unknown-linux-musl",
   "max-atomic-width": 64,
   "metadata": {
-    "description": null,
-    "host_tools": null,
-    "std": null,
-    "tier": null
+    "description": "64-bit Linux with musl 1.2.3",
+    "host_tools": true,
+    "std": true,
+    "tier": 2
   },
   "os": "linux",
   "plt-by-default": false,

--- a/hashes/rust
+++ b/hashes/rust
@@ -1,15 +1,15 @@
-# https://static.rust-lang.org/dist/rustc-1.79.0-src.tar.xz
-SHA512 (rustc-1.79.0-src.tar.xz) = 99d7f276292e5c270648473ff73e9888413a3325ef3a4d7a45f8ce77a42ac87996905f1d875888ce084b621f642017bc9e31a00da1439108dbe19b85d0eab085
-### See https://raw.githubusercontent.com/rust-lang/rust/1.79.0/src/stage0.json for what to use below. ###
-# https://static.rust-lang.org/dist/2024-05-02/rust-std-1.78.0-x86_64-unknown-linux-gnu.tar.xz
-SHA512 (rust-std-1.78.0-x86_64-unknown-linux-gnu.tar.xz) = 8d88664cc73b2937d9124f593b08ba61ef14c027cefdd97973954a66886658567ea9eb9f505441e985ba1053d1bee7dba0cfa8cdd65456a3abec6fe809c65b87
-# https://static.rust-lang.org/dist/2024-05-02/rustc-1.78.0-x86_64-unknown-linux-gnu.tar.xz
-SHA512 (rustc-1.78.0-x86_64-unknown-linux-gnu.tar.xz) = d3290a5764304d265713b0724d94f5d986aaa47c2a6407f6234daf7dd5d4eacfe4642559c72ce17e4d4395e55bbd40f19e88f0db6653963aa29cec8cf6c0f8e0
-# https://static.rust-lang.org/dist/2024-05-02/cargo-1.78.0-x86_64-unknown-linux-gnu.tar.xz
-SHA512 (cargo-1.78.0-x86_64-unknown-linux-gnu.tar.xz) = feb72154e052d275cb9fe5c9bec6514ddfedf1872cd64c3f6665fec2e8f0e257a83b3273d8b11090f1ae810c71c204ebc7d1bec4352107b84c0e0e3babaf8859
-# https://static.rust-lang.org/dist/2024-05-02/rust-std-1.78.0-aarch64-unknown-linux-gnu.tar.xz
-SHA512 (rust-std-1.78.0-aarch64-unknown-linux-gnu.tar.xz) = 08219c9c05dd164b0f9d9424602a73b8b6248461eb9aa75a8c365a72332eeabe8d533b33a578efa0fbcf994a316a55be3d849aedfbf204bc08e2fc22ab59e8a9
-# https://static.rust-lang.org/dist/2024-05-02/rustc-1.78.0-aarch64-unknown-linux-gnu.tar.xz
-SHA512 (rustc-1.78.0-aarch64-unknown-linux-gnu.tar.xz) = c7299e8ea776a78f74b9f1d196c4872e7ac81f75ca14447c811758df73d90a89e6dee77ccbbff1cff0a3033bc49cf6936cd545e0b359d7650ecd05314fc813b9
-# https://static.rust-lang.org/dist/2024-05-02/cargo-1.78.0-aarch64-unknown-linux-gnu.tar.xz
-SHA512 (cargo-1.78.0-aarch64-unknown-linux-gnu.tar.xz) = f48b3de9be3a9cf89ee6d469398a364f4b2e45f98d3126141c44d74c3c3d1806c90fc9098b749eed235d680a5e1ff3899c3ccd0166ff740210e5b4e32b3f8f0b
+# https://static.rust-lang.org/dist/rustc-1.80.1-src.tar.xz
+SHA512 (rustc-1.80.1-src.tar.xz) = 3c746108a86eeb734c1a8c8f63ba1a45e2cb03a8cb553395a167d07dc3ce5d8d9ea365ddd95533b6952d915069b86cad7ad218d27861e0889f8e878136bd32ab
+### See https://raw.githubusercontent.com/rust-lang/rust/1.80.1/src/stage0 for what to use below. ###
+# https://static.rust-lang.org/dist/2024-06-13/rust-std-1.79.0-x86_64-unknown-linux-gnu.tar.xz
+SHA512 (rust-std-1.79.0-x86_64-unknown-linux-gnu.tar.xz) = b00bce12f1b9f6fdb7c67f27a932ecaf9eef2970efb1a1914c2082ca979ad15e4e3ef3709ac5b4ea4ceafbdb4b9d2130f620f6abc607bee4b343d9971501af25
+# https://static.rust-lang.org/dist/2024-06-13/rustc-1.79.0-x86_64-unknown-linux-gnu.tar.xz
+SHA512 (rustc-1.79.0-x86_64-unknown-linux-gnu.tar.xz) = f9d25ccb3fbe165d2089c37002f9d62578588b9f361ff9353e9673a46e1f46940eb5dcb494c1546faa033ba016b5eff3a9d47ac1595d7be3d207ed5ac9267179
+# https://static.rust-lang.org/dist/2024-06-13/cargo-1.79.0-x86_64-unknown-linux-gnu.tar.xz
+SHA512 (cargo-1.79.0-x86_64-unknown-linux-gnu.tar.xz) = d617805f16a18221554421845ddd37d731f4d1baab3df0a8b5a2195ff38813b5a74ebb08c410fb190cd73e1e2440e9df37faef13b01d3e4ed5ebd78216a62ad5
+# https://static.rust-lang.org/dist/2024-06-13/rust-std-1.79.0-aarch64-unknown-linux-gnu.tar.xz
+SHA512 (rust-std-1.79.0-aarch64-unknown-linux-gnu.tar.xz) = dc2b845336608619f8183256f6c1234d4a309a3ed89cd1c29420b8c75773e4b197e6f3c000675b3122f7422df8024db1324e482e558af95008be0886d0410c41
+# https://static.rust-lang.org/dist/2024-06-13/rustc-1.79.0-aarch64-unknown-linux-gnu.tar.xz
+SHA512 (rustc-1.79.0-aarch64-unknown-linux-gnu.tar.xz) = 9351ba5818bdeafb2a9b315dd1dcdb9ed2a296b491a511a61b45e8c881cf32b9de6e89cba495860c57e1602c1d22b5bfe809d59c037d838804653c60ff599b68
+# https://static.rust-lang.org/dist/2024-06-13/cargo-1.79.0-aarch64-unknown-linux-gnu.tar.xz
+SHA512 (cargo-1.79.0-aarch64-unknown-linux-gnu.tar.xz) = 2476d4afa0aa19bdbc5b623f09122d97c0dc42f5e4437eec7d2d299bf622154a1b3e6460f892b22b8dd91da5ef60e383886be1fecbd7a7734b09359549ab5c28

--- a/hashes/rust
+++ b/hashes/rust
@@ -1,15 +1,15 @@
-# https://static.rust-lang.org/dist/rustc-1.80.1-src.tar.xz
-SHA512 (rustc-1.80.1-src.tar.xz) = 3c746108a86eeb734c1a8c8f63ba1a45e2cb03a8cb553395a167d07dc3ce5d8d9ea365ddd95533b6952d915069b86cad7ad218d27861e0889f8e878136bd32ab
-### See https://raw.githubusercontent.com/rust-lang/rust/1.80.1/src/stage0 for what to use below. ###
-# https://static.rust-lang.org/dist/2024-06-13/rust-std-1.79.0-x86_64-unknown-linux-gnu.tar.xz
-SHA512 (rust-std-1.79.0-x86_64-unknown-linux-gnu.tar.xz) = b00bce12f1b9f6fdb7c67f27a932ecaf9eef2970efb1a1914c2082ca979ad15e4e3ef3709ac5b4ea4ceafbdb4b9d2130f620f6abc607bee4b343d9971501af25
-# https://static.rust-lang.org/dist/2024-06-13/rustc-1.79.0-x86_64-unknown-linux-gnu.tar.xz
-SHA512 (rustc-1.79.0-x86_64-unknown-linux-gnu.tar.xz) = f9d25ccb3fbe165d2089c37002f9d62578588b9f361ff9353e9673a46e1f46940eb5dcb494c1546faa033ba016b5eff3a9d47ac1595d7be3d207ed5ac9267179
-# https://static.rust-lang.org/dist/2024-06-13/cargo-1.79.0-x86_64-unknown-linux-gnu.tar.xz
-SHA512 (cargo-1.79.0-x86_64-unknown-linux-gnu.tar.xz) = d617805f16a18221554421845ddd37d731f4d1baab3df0a8b5a2195ff38813b5a74ebb08c410fb190cd73e1e2440e9df37faef13b01d3e4ed5ebd78216a62ad5
-# https://static.rust-lang.org/dist/2024-06-13/rust-std-1.79.0-aarch64-unknown-linux-gnu.tar.xz
-SHA512 (rust-std-1.79.0-aarch64-unknown-linux-gnu.tar.xz) = dc2b845336608619f8183256f6c1234d4a309a3ed89cd1c29420b8c75773e4b197e6f3c000675b3122f7422df8024db1324e482e558af95008be0886d0410c41
-# https://static.rust-lang.org/dist/2024-06-13/rustc-1.79.0-aarch64-unknown-linux-gnu.tar.xz
-SHA512 (rustc-1.79.0-aarch64-unknown-linux-gnu.tar.xz) = 9351ba5818bdeafb2a9b315dd1dcdb9ed2a296b491a511a61b45e8c881cf32b9de6e89cba495860c57e1602c1d22b5bfe809d59c037d838804653c60ff599b68
-# https://static.rust-lang.org/dist/2024-06-13/cargo-1.79.0-aarch64-unknown-linux-gnu.tar.xz
-SHA512 (cargo-1.79.0-aarch64-unknown-linux-gnu.tar.xz) = 2476d4afa0aa19bdbc5b623f09122d97c0dc42f5e4437eec7d2d299bf622154a1b3e6460f892b22b8dd91da5ef60e383886be1fecbd7a7734b09359549ab5c28
+# https://static.rust-lang.org/dist/rustc-1.81.0-src.tar.xz
+SHA512 (rustc-1.81.0-src.tar.xz) = b8a837ced521d2ca2c7f228a0640da591384519e4dbc1ae768524d50616da6abbd2f7bdae3777caebc0447dac91bf76481282ce5a2264d7f30e173caa6321a51
+### See https://raw.githubusercontent.com/rust-lang/rust/1.81.0/src/stage0 for what to use below. ###
+# https://static.rust-lang.org/dist/2024-08-08/rust-std-1.80.1-x86_64-unknown-linux-gnu.tar.xz
+SHA512 (rust-std-1.80.1-x86_64-unknown-linux-gnu.tar.xz) = 18aeaf8235c2b803294199cd15c0439890816cb29767b0e77520b71d4e7848e45858a28a438a4f88d90d235095a62cbe2dad73fa5ec50464c8984430be239457
+# https://static.rust-lang.org/dist/2024-08-08/rustc-1.80.1-x86_64-unknown-linux-gnu.tar.xz
+SHA512 (rustc-1.80.1-x86_64-unknown-linux-gnu.tar.xz) = 4c21cc6c29fccee2359f997654850f5d8cadddcdbde5bd4d99a4002d1be4310ee4cbb39ac97ef1092cbe080146efc94d93969aaffd5a1425a642c62ab5fc4e5f
+# https://static.rust-lang.org/dist/2024-08-08/cargo-1.80.1-x86_64-unknown-linux-gnu.tar.xz
+SHA512 (cargo-1.80.1-x86_64-unknown-linux-gnu.tar.xz) = 49d89aafd7ef1857e9d0794ffdae64d205565c764d18ea3920dfa2d893114b6c9ea304592d091130c69fe828a0af84fe34e96c3fcaa4f77ee959cde140890216
+# https://static.rust-lang.org/dist/2024-08-08/rust-std-1.80.1-aarch64-unknown-linux-gnu.tar.xz
+SHA512 (rust-std-1.80.1-aarch64-unknown-linux-gnu.tar.xz) = 1414675a093dc8e79a2b36457316f4e86062d8f88e2ae3d7e2099aceb32380444851b780661dc2c2649543e15f866f67456134b6d60b6bc386fda2bfd025b8e4
+# https://static.rust-lang.org/dist/2024-08-08/rustc-1.80.1-aarch64-unknown-linux-gnu.tar.xz
+SHA512 (rustc-1.80.1-aarch64-unknown-linux-gnu.tar.xz) = 284e2f58ec10586c79ba30c56b743fb83ccd01719af930cfa395585d45636fe6a356a3a643d2dd6ad23c3c500503265831a43a80974fc0f4456f54bf0c013c25
+# https://static.rust-lang.org/dist/2024-08-08/cargo-1.80.1-aarch64-unknown-linux-gnu.tar.xz
+SHA512 (cargo-1.80.1-aarch64-unknown-linux-gnu.tar.xz) = 005d8640531d6ad628eaef2d0039f1f1a7e6e54ac5217f13240949956aeff602014b3c878f81f2fb055f1a103e395033af8230f59a3070681974ea3e81110bce


### PR DESCRIPTION
<!--
Tips:
- Please read the CONTRIBUTING document to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->

**Issue number:**
N/A


**Description of changes:**
The old approach of defining our targets - which was always a hack - stopped working after https://github.com/rust-lang/rust/commit/09c076810cb7649e5817f316215010d49e78e8d7 added a check to ensure the target was either a custom target or recognized by the bootstrap toolchain.

Rather than fight it, I've extended the `update-rust.sh` script to regenerate custom targets that add the vendor field. The custom targets are needed both at build time and on the final system.

`stage0.json` went away in https://github.com/rust-lang/rust/pull/124883/commits/aa2faefe12498a6aaa8abfb9cbda5d848023dcc7, so adapt to the new `stage0` file.

**Testing done:**
Built the SDK for x86_64 and aarch64 hosts. Built the core kit for both architectures using each SDK. Verified that variants could be built and launched.


**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
