### PR TITLE
add `-fno-omit-frame-pointer` to CFLAGS

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -545,7 +545,7 @@ FROM sdk-libc as sdk-go-prep
 # Set up the environment for building.
 ENV GOOS="linux"
 ENV CGO_ENABLED=1
-ENV CFLAGS="-O2 -g -pipe -Wformat -Werror=format-security -Wp,-D_FORTIFY_SOURCE=2 -Wp,-D_GLIBCXX_ASSERTIONS -fexceptions -fstack-clash-protection"
+ENV CFLAGS="-O2 -g -pipe -Wformat -Werror=format-security -Wp,-D_FORTIFY_SOURCE=2 -Wp,-D_GLIBCXX_ASSERTIONS -fexceptions -fstack-clash-protection -fno-omit-frame-pointer"
 ENV CXXFLAGS="${CFLAGS}"
 ENV LDFLAGS="-Wl,-z,relro -Wl,-z,now"
 ENV CGO_CFLAGS="${CFLAGS}"

--- a/helpers/aws-lc/build-aws-lc.sh
+++ b/helpers/aws-lc/build-aws-lc.sh
@@ -19,7 +19,7 @@ TARGET="${ARCH}-bottlerocket-linux-gnu"
 # Some of the AWS-LC sources are built with `-O0`. This is not compatible with
 # `-Wp,-D_FORTIFY_SOURCE=2`, which needs at least `-O2`. Add `-DGOBORING` to
 # avoid weak symbols.
-CFLAGS="${CFLAGS} -Wp,-U_FORTIFY_SOURCE -DGOBORING"
+CFLAGS="${CFLAGS} -Wp,-U_FORTIFY_SOURCE -DGOBORING -fno-omit-frame-pointer"
 
 cd "${HOME}/aws-lc/build"
 cmake \

--- a/helpers/glibc/build-glibc.sh
+++ b/helpers/glibc/build-glibc.sh
@@ -16,7 +16,7 @@ KVER="${KVER:?}"
 
 TARGET="${ARCH}-bottlerocket-linux-gnu"
 SYSROOT="/${TARGET}/sys-root"
-BUILDFLAGS="-O2 -g -Wp,-D_GLIBCXX_ASSERTIONS -fstack-clash-protection"
+BUILDFLAGS="-O2 -g -Wp,-D_GLIBCXX_ASSERTIONS -fstack-clash-protection -fno-omit-frame-pointer"
 
 cd "${HOME}/glibc/build"
 CFLAGS="${BUILDFLAGS}" CPPFLAGS="" CXXFLAGS="${BUILDFLAGS}" \

--- a/helpers/libunwind/build-libunwind.sh
+++ b/helpers/libunwind/build-libunwind.sh
@@ -14,7 +14,7 @@ ARCH="${ARCH:?}"
 
 TARGET="${ARCH}-bottlerocket-linux-musl"
 SYSROOT="/${TARGET}/sys-root"
-export CFLAGS="-O2 -g -pipe -Wall -Werror=format-security -Wp,-D_FORTIFY_SOURCE=2 -Wp,-D_GLIBCXX_ASSERTIONS -fexceptions -fstack-clash-protection"
+export CFLAGS="-O2 -g -pipe -Wall -Werror=format-security -Wp,-D_FORTIFY_SOURCE=2 -Wp,-D_GLIBCXX_ASSERTIONS -fexceptions -fstack-clash-protection -fno-omit-frame-pointer"
 export LDFLAGS="-Wl,-z,relro -Wl,-z,now"
 
 cd "${HOME}/libunwind/build"

--- a/helpers/musl/build-musl.sh
+++ b/helpers/musl/build-musl.sh
@@ -14,7 +14,7 @@ ARCH="${ARCH:?}"
 
 TARGET="${ARCH}-bottlerocket-linux-musl"
 SYSROOT="/${TARGET}/sys-root"
-CFLAGS="-O2 -g -pipe -Wall -Werror=format-security -Wp,-D_FORTIFY_SOURCE=2 -Wp,-D_GLIBCXX_ASSERTIONS -fexceptions -fstack-clash-protection"
+CFLAGS="-O2 -g -pipe -Wall -Werror=format-security -Wp,-D_FORTIFY_SOURCE=2 -Wp,-D_GLIBCXX_ASSERTIONS -fexceptions -fstack-clash-protection -fno-omit-frame-pointer"
 LDFLAGS="-Wl,-z,relro -Wl,-z,now"
 
 cd "${HOME}/musl"

--- a/macros/rust
+++ b/macros/rust
@@ -9,7 +9,7 @@
 %__rustdoc %{_bindir}/rustdoc
 
 # Enable optimization, debuginfo, and link hardening.
-%__global_rustflags -Copt-level=3 -Cdebuginfo=2 -Ccodegen-units=1 -Clink-arg=-Wl,-z,relro,-z,now
+%__global_rustflags -Copt-level=3 -Cdebuginfo=2 -Ccodegen-units=1 -Cforce-frame-pointers=yes -Clink-arg=-Wl,-z,relro,-z,now
 
 # Enable dynamic linking.
 %__global_rustflags_shared -Cprefer-dynamic %__global_rustflags

--- a/macros/shared
+++ b/macros/shared
@@ -10,14 +10,14 @@
   -Werror=format-security -Werror=strict-aliasing \
   -Wp,-U_FORTIFY_SOURCE -Wp,-D_FORTIFY_SOURCE=2 \
   -Wp,-D_GLIBCXX_ASSERTIONS \
-  -fexceptions -fstack-clash-protection -fno-semantic-interposition \
+  -fexceptions -fstack-clash-protection -fno-semantic-interposition -fno-omit-frame-pointer \
   %{nil}}
 %_cross_c_args %{shrink: \
   '-O2', '-g', '-pipe', '-Wall', \
   '-Werror=format-security', '-Werror=strict-aliasing', \
   '-Wp,-U_FORTIFY_SOURCE', '-Wp,-D_FORTIFY_SOURCE=2', \
   '-Wp,-D_GLIBCXX_ASSERTIONS', \
-  '-fexceptions', '-fstack-clash-protection', '-fno-semantic-interposition' \
+  '-fexceptions', '-fstack-clash-protection', '-fno-semantic-interposition', '-fno-omit-frame-pointer' \
   %{nil}}
 %_cross_cxxflags %_cross_cflags
 %_cross_ldflags -Wl,-z,relro -Wl,-z,now -Wl,-Bsymbolic-functions


### PR DESCRIPTION
<!--
Tips:
- Please read the CONTRIBUTING document to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->

**Issue number:**

#205

**Description of changes:**

This PR adds the `-f-no-omit-frame-pointer` CFLAG to several build processes of the SDK to add frame pointers back into system libraries.

**Testing done:**

<none yet>

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
