### PR TITLE
Add FIPS support for Rust binaries

### DIFF
--- a/macros/cargo
+++ b/macros/cargo
@@ -16,15 +16,45 @@
 %__cargo_cross_opts %{__cargo_common_opts} --target %{__cargo_target}
 %__cargo_cross_opts_static %{__cargo_common_opts} --target %{__cargo_target_static}
 %__cargo_env CARGO_TARGET_DIR="${HOME}/.cache" SKIP_README="true"
+%__cargo_env_fips CARGO_TARGET_DIR="${HOME}/.cache/.fips" SKIP_README="true"
+%__cargo_env_aws_sdk CARGO_TARGET_DIR="${HOME}/.cache/.aws-sdk" SKIP_README="true" RUSTFLAGS="%{__global_rustflags_aws_sdk}"
+%__cargo_env_fips_aws_sdk CARGO_TARGET_DIR="${HOME}/.cache/.fips/.aws-sdk" SKIP_README="true" RUSTFLAGS="%{__global_rustflags_aws_sdk}"
 %__cargo_env_static CARGO_TARGET_DIR="${HOME}/.cache/.static" SKIP_README="true"
+%__cargo_env_static_fips CARGO_TARGET_DIR="${HOME}/.cache/.fips/.static" SKIP_README="true"
 %__cargo_outdir "${HOME}/.cache/%{__cargo_target}/release"
+%__cargo_outdir_fips "${HOME}/.cache/.fips/%{__cargo_target}/release"
+%__cargo_outdir_aws_sdk "${HOME}/.cache/.aws-sdk/%{__cargo_target}/release"
+%__cargo_outdir_aws_sdk_fips "${HOME}/.cache/.fips/.aws-sdk/%{__cargo_target}/release"
 %__cargo_outdir_static "${HOME}/.cache/.static/%{__cargo_target_static}/release"
+%__cargo_outdir_static_fips "${HOME}/.cache/.fips/.static/%{__cargo_target_static}/release"
 %__cargo_cross_pkg_config PKG_CONFIG_PATH="%{_cross_pkgconfigdir}" PKG_CONFIG_ALLOW_CROSS=1
-%__cargo_cross_env %{__cargo_env} %{__cargo_cross_pkg_config} TARGET_CC="%{_cross_triple}-gnu-gcc"
-%__cargo_cross_env_static %{__cargo_env_static} %{__cargo_cross_pkg_config} TARGET_CC="%{_cross_triple}-musl-gcc"
+
+%__cargo_cross_env_base \
+  CMAKE_TOOLCHAIN_FILE="%{_cross_cmake_toolchain_conf}" ; \
+  export CMAKE_TOOLCHAIN_FILE ; \
+  BINDGEN_EXTRA_CLANG_ARGS="--target=%{_cross_target} --sysroot=%{_cross_rootdir}" ; \
+  export BINDGEN_EXTRA_CLANG_ARGS ; \
+  %{__cargo_cross_pkg_config}
+
+%__cargo_cross_env_static_base \
+  CMAKE_TOOLCHAIN_FILE="%{_cross_cmake_toolchain_conf_static}" ; \
+  export CMAKE_TOOLCHAIN_FILE ; \
+  BINDGEN_EXTRA_CLANG_ARGS="--target=%{_cross_triple}-musl --sysroot=/%{_cross_triple}-musl/sys-root" ; \
+  export BINDGEN_EXTRA_CLANG_ARGS ; \
+  %{__cargo_cross_pkg_config}
+
+%__cargo_cross_env %{__cargo_cross_env_base} %{__cargo_env} TARGET_CC="%{_cross_triple}-gnu-gcc"
+%__cargo_cross_env_aws_sdk %{__cargo_cross_env_base} %{__cargo_env_aws_sdk} TARGET_CC="%{_cross_triple}-gnu-gcc"
+%__cargo_cross_env_fips %{__cargo_cross_env_base} %{__cargo_env_fips} TARGET_CC="%{_cross_triple}-gnu-gcc"
+%__cargo_cross_env_fips_aws_sdk %{__cargo_cross_env_base} %{__cargo_env_fips_aws_sdk} TARGET_CC="%{_cross_triple}-gnu-gcc"
+%__cargo_cross_env_static %{__cargo_cross_env_static_base} %{__cargo_env_static} TARGET_CC="%{_cross_triple}-musl-gcc"
+%__cargo_cross_env_static_fips %{__cargo_cross_env_static_base} %{__cargo_env_static_fips} TARGET_CC="%{_cross_triple}-musl-gcc"
+
 %__cargo_incremental false
 
 %cargo_prep (\
+%write_cross_cmake_toolchain_conf \
+%write_cross_cmake_toolchain_conf_static \
 %{__mkdir} -p %{_builddir}/.cargo \
 cat > %{_builddir}/.cargo/config << EOF \
 [build]\
@@ -45,4 +75,8 @@ EOF\
 )
 
 %cargo_build %{__cargo_cross_env} %{__cargo} build %{__cargo_cross_opts} --release %{?cargo_args}
+%cargo_build_aws_sdk %{__cargo_cross_env_aws_sdk} %{__cargo} build %{__cargo_cross_opts} --release %{?cargo_args}
+%cargo_build_fips %{__cargo_cross_env_fips} %{__cargo} build %{__cargo_cross_opts} --release --features fips %{?cargo_args}
+%cargo_build_fips_aws_sdk %{__cargo_cross_env_fips_aws_sdk} %{__cargo} build %{__cargo_cross_opts} --release --features fips %{?cargo_args}
 %cargo_build_static %{__cargo_cross_env_static} %{__cargo} build %{__cargo_cross_opts_static} --release %{?cargo_args}
+%cargo_build_static_fips %{__cargo_cross_env_static_fips} %{__cargo} build %{__cargo_cross_opts_static} --release --features fips %{?cargo_args}

--- a/macros/check-fips
+++ b/macros/check-fips
@@ -45,13 +45,11 @@ uses_go_boring_crypto() {
   grep -Fq -m1 'goboringcrypto' <<<"${output}"
 }
 
-found=0
-not_found=0
-miscompiled=0
-for b in $(find "${BUILDROOT_BINDIR}" "${BUILDROOT_LIBEXECDIR}" -type f -executable) ; do
-  if is_go_bin "${b}" && uses_go_crypto_tls "${b}" ; then
-    f="${b/${BUILDROOT_BINDIR}/${BUILDROOT_FIPS_BINDIR}}"
-    f="${f/${BUILDROOT_LIBEXECDIR}/${BUILDROOT_FIPS_LIBEXECDIR}}"
+check_go_bin() {
+  local b f
+  b="${1:?}"
+  f="${2:?}"
+  if uses_go_crypto_tls "${b}" ; then
     if [ -s "${f}" ] ; then
       echo "${b} uses Go crypto/tls and FIPS build found in ${f}"
       (( found+=1 ))
@@ -67,6 +65,76 @@ for b in $(find "${BUILDROOT_BINDIR}" "${BUILDROOT_LIBEXECDIR}" -type f -executa
       echo "${b} uses Go crypto/tls but no FIPS build found in ${f}" >&2
       (( not_found+=1 ))
     fi
+  fi
+}
+
+is_rust_bin() {
+  local bin output
+  bin="${1:?}"
+  output="$("${STRINGS}" "${bin}")"
+  grep -Fq -m1 -e 'rust_alloc' -e 'rust_begin' <<<"${output}"
+}
+
+uses_ring() {
+  local bin output
+  bin="${1:?}"
+  output="$("${STRINGS}" "${bin}")"
+  grep -Fq -m1 '/ring' <<<"${output}"
+}
+
+uses_aws_lc_rs() {
+  local bin output
+  bin="${1:?}"
+  output="$("${STRINGS}" "${bin}")"
+  grep -Fq -m1 'aws-lc-rs' <<<"${output}"
+}
+
+uses_aws_lc_fips_sys() {
+  local bin output
+  bin="${1:?}"
+  output="$("${STRINGS}" "${bin}")"
+  grep -Fq -m1 'aws-lc-fips-sys' <<<"${output}"
+}
+
+check_rust_bin() {
+  local b f
+  b="${1:?}"
+  f="${2:?}"
+
+  if uses_aws_lc_rs "${b}"; then
+    if [ -s "${f}" ] ; then
+      echo "${b} uses aws-lc-rs and FIPS build found in ${f}"
+      (( found+=1 ))
+      if uses_aws_lc_fips_sys "${b}" ; then
+        echo "${b} is built with aws-lc-rs in FIPS mode rather than standard aws-lc-rs" >&2
+        (( miscompiled+=1 ))
+      fi
+      if ! uses_aws_lc_fips_sys "${f}"; then
+        echo "${f} is built with standard aws-lc-rs rather than in FIPS mode" >&2
+        (( miscompiled+=1 ))
+      fi
+    else
+      echo "${b} uses aws-lc-rs but no FIPS build found in ${f}" >&2
+      (( not_found+=1 ))
+    fi
+  else
+    if uses_ring "${b}"; then
+      echo "${b} must use aws-lc-rs" >&2
+      (( miscompiled+=1 ))
+    fi
+  fi
+}
+
+found=0
+not_found=0
+miscompiled=0
+for b in $(find "${BUILDROOT_BINDIR}" "${BUILDROOT_LIBEXECDIR}" -type f -executable) ; do
+  f="${b/${BUILDROOT_BINDIR}/${BUILDROOT_FIPS_BINDIR}}"
+  f="${f/${BUILDROOT_LIBEXECDIR}/${BUILDROOT_FIPS_LIBEXECDIR}}"
+  if is_go_bin "${b}"; then
+    check_go_bin "${b}" "${f}"
+  elif is_rust_bin "${b}"; then
+    check_rust_bin "${b}" "${f}"
   fi
 done
 

--- a/macros/rust
+++ b/macros/rust
@@ -8,8 +8,14 @@
 %__rustc %{_bindir}/rustc
 %__rustdoc %{_bindir}/rustdoc
 
-# Enable optimization, debuginfo, and link hardening.
-%__global_rustflags -Copt-level=3 -Cdebuginfo=2 -Ccodegen-units=1 -Cforce-frame-pointers=yes -Clink-arg=-Wl,-z,relro,-z,now
+# Enable some optimization, debuginfo, and link hardening.
+%__global_rustflags_base -Copt-level=3 -Cdebuginfo=2 -Cforce-frame-pointers=yes -Clink-arg=-Wl,-z,relro,-z,now
+
+# Optimize generated code by using one codegen unit
+%__global_rustflags -Ccodegen-units=1 %__global_rustflags_base
+
+# Pessimize AWS SDK binaries in favor of faster builds
+%__global_rustflags_aws_sdk -Cprefer-dynamic %__global_rustflags_base
 
 # Enable dynamic linking.
 %__global_rustflags_shared -Cprefer-dynamic %__global_rustflags

--- a/macros/shared
+++ b/macros/shared
@@ -152,22 +152,70 @@ CROSS_COMPILATION_CONF_EOF\
 %cross_meson_install \
   %ninja_install -C %{_cross_vpath_builddir}
 
+%_cross_cmake_toolchain_conf %{_builddir}/toolchain.%{_cross_target}.cmake
+
+%write_cross_cmake_toolchain_conf \
+cat <<CROSS_CMAKE_TOOLCHAIN_EOF > %_cross_cmake_toolchain_conf 2>/dev/null || :\
+set(CMAKE_SYSTEM_NAME Linux)\
+set(CMAKE_BUILD_TYPE Release)\
+set(CMAKE_VERBOSE_MAKEFILE TRUE)\
+set(CMAKE_SKIP_RPATH TRUE)\
+set(CMAKE_INSTALL_PREFIX %{_cross_prefix})\
+set(CMAKE_SYSTEM_PROCESSOR %{_cross_arch})\
+set(triple %{_cross_triple})\
+set(CMAKE_SYSROOT %{_cross_rootdir})\
+set(CMAKE_C_COMPILER %{_cross_target}-gcc)\
+set(CMAKE_C_COMPILER_TARGET %_cross_target)\
+set(CMAKE_CXX_COMPILER %{_cross_target}-g++)\
+set(CMAKE_CXX_COMPILER_TARGET %_cross_target)\
+set(CMAKE_C_FLAGS "%{_cross_cflags}")\
+set(CMAKE_C_FLAGS_RELEASE "-DNDEBUG")\
+set(CMAKE_CXX_FLAGS "%{_cross_cxxflags}")\
+set(CMAKE_CXX_FLAGS_RELEASE "-DNDEBUG")\
+set(CMAKE_FIND_ROOT_PATH_MODE_PROGRAM NEVER)\
+set(CMAKE_FIND_ROOT_PATH_MODE_LIBRARY ONLY)\
+set(CMAKE_FIND_ROOT_PATH_MODE_INCLUDE ONLY)\
+set(CMAKE_FIND_ROOT_PATH_MODE_PACKAGE ONLY)\
+CROSS_CMAKE_TOOLCHAIN_EOF\
+%{nil}
+
+%_cross_cmake_toolchain_conf_static %{_builddir}/toolchain.%{_cross_triple}-musl.static.cmake
+
+%write_cross_cmake_toolchain_conf_static \
+cat <<CROSS_CMAKE_TOOLCHAIN_EOF > %_cross_cmake_toolchain_conf_static 2>/dev/null || :\
+set(CMAKE_SYSTEM_NAME Linux)\
+set(CMAKE_BUILD_TYPE Release)\
+set(CMAKE_VERBOSE_MAKEFILE TRUE)\
+set(CMAKE_SKIP_RPATH TRUE)\
+set(CMAKE_SYSTEM_PROCESSOR %{_cross_arch})\
+set(triple %{_cross_triple})\
+set(CMAKE_SYSROOT /%{_cross_triple}-musl/sys-root)\
+set(CMAKE_C_COMPILER %{_cross_triple}-musl-gcc)\
+set(CMAKE_C_COMPILER_TARGET %{_cross_triple}-musl)\
+set(CMAKE_CXX_COMPILER %{_cross_triple}-musl-g++)\
+set(CMAKE_CXX_COMPILER_TARGET %{_cross_triple}-musl)\
+set(CMAKE_C_FLAGS "%{_cross_cflags}")\
+set(CMAKE_C_FLAGS_RELEASE "-DNDEBUG")\
+set(CMAKE_CXX_FLAGS "%{_cross_cxxflags}")\
+set(CMAKE_CXX_FLAGS_RELEASE "-DNDEBUG")\
+set(CMAKE_FIND_ROOT_PATH_MODE_PROGRAM NEVER)\
+set(CMAKE_FIND_ROOT_PATH_MODE_LIBRARY ONLY)\
+set(CMAKE_FIND_ROOT_PATH_MODE_INCLUDE ONLY)\
+set(CMAKE_FIND_ROOT_PATH_MODE_PACKAGE ONLY)\
+CROSS_CMAKE_TOOLCHAIN_EOF\
+%{nil}
+
 %cross_cmake \
+  %write_cross_cmake_toolchain_conf \
   %set_cross_build_flags \
+  CMAKE_TOOLCHAIN_FILE="%{_cross_cmake_toolchain_conf}" ; \
+  export CMAKE_TOOLCHAIN_FILE ; \
   %{shrink:%{__cmake} \
-    -DCMAKE_C_SYSTEM_NAME:STRING="Linux" \
-    -DCMAKE_C_COMPILER:STRING="%{_cross_target}-gcc" \
-    -DCMAKE_C_FLAGS_RELEASE:STRING="-DNDEBUG" \
-    -DCMAKE_CXX_FLAGS_RELEASE:STRING="-DNDEBUG" \
-    -DCMAKE_BUILD_TYPE="Release" \
-    -DCMAKE_VERBOSE_MAKEFILE:BOOL=ON \
-    -DCMAKE_INSTALL_PREFIX:PATH=%{_cross_prefix} \
     -DINCLUDE_INSTALL_DIR:PATH=%{_cross_includedir} \
     -DLIB_INSTALL_DIR:PATH=%{_cross_libdir} \
     -DSYSCONF_INSTALL_DIR:PATH=%{_cross_sysconfdir} \
     -DSHARE_INSTALL_PREFIX:PATH=%{_cross_datadir} \
     -DBUILD_SHARED_LIBS:BOOL=ON \
-    -DCMAKE_SKIP_RPATH:BOOL=ON \
     %{nil}}
 
 %_cross_go_os linux


### PR DESCRIPTION
**Issue number:**
N / A


**Description of changes:**

This includes the changes required to build Rust binaries with FIPS support.

The first commit introduces the macros required to compile FIPS and non-FIPS binaries for both statically and dynamically compiled crates, as well as a new macro to compile binaries that depend on the `aws-sdk` . 

The `aws-lc-rs` crate's build script compiles `aws-lc` whenever the crate is build. The build script will pass the `CMAKE_TOOLCHAIN_FILE` environment variable to `cmake` in order to configure the cross compiler that should be used to compile the library. With this change, the `cargo_prep` macro generates and uses the `cmake` toolchain files for both static and dynamic builds. As part of this change, the `cross_cmake` macro was migrated to the new macros that generate the toolchain file.

All the FIPS binaries are created at `${HOME}/.cache/.fips/<type>` instead of having a `.fips` directory for every build type given that in the latter structure, the static builds would collide with each other and the FIPS build would fail with `No such file or directory errors` .

 The second commit in the series extends the `check-fips` script to detect whenever a Rust binary should include the extra FIPS copy. The script detects if a binary depends on `ring` but not in `aws-lc-rs`. This is to prevent relying on `ring` as the crypto backend for the rust programs included in Bottlerocket. Additionally, the binary detects when either the fips and non-fips binaries were compiled with the wrong `aws-lc-rs` flag, similar to the existing `go` check. 


**Testing done:**

- In a local change, I confirmed that `pluto` was compiled successfully after I migrated it to `aws-smithy-experimental`
- In a local change, I confirmed that the `apiclient` compiled successfully, with FIPS support
- In a local build, I confirmed the build failed to pass the `check-fips` check due to the missing `fips` binaries for a few packages
- In a local build, I confirmed that `docker-init` (the only package that depends on `cross_cmake`) compiled successfully

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
