### PR TITLE
macros, build: override find-debuginfo location

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1183,15 +1183,19 @@ RUN \
 
 # =^..^=   =^..^=   =^..^=   =^..^=   =^..^=   =^..^=   =^..^=   =^..^=   =^..^=
 #
-# Create symlinks that can be added to $PATH to override programs invoked by
-# find-debuginfo.sh, which does not expect to add a prefix.
+# find-debuginfo adds the directory where it's located as the first entry in $PATH.
+# Set up a directory for each architecture containing the unprefixed versions of
+# the binutils programs, along with a link to find-debuginfo, so that it will work
+# as expected when extracting and stripping debuginfo from binaries built for the
+# target architecture.
 FROM sdk as sdk-find-debuginfo-symlinks
 RUN \
   for arch in x86_64 aarch64 ; do \
     triple="${arch}-bottlerocket-linux-gnu" ; \
     debuginfo_bindir="/usr/${triple}/debuginfo/bin" ; \
     mkdir -p "${debuginfo_bindir}" ; \
-    for b in nm objcopy objdump strip ; do \
+    ln -sr /usr/bin/find-debuginfo "${debuginfo_bindir}/find-debuginfo" ; \
+    for b in nm objcopy objdump readelf strip ; do \
       ln -sr "/usr/bin/${triple}-${b}" "${debuginfo_bindir}/${b}" ; \
     done ; \
   done

--- a/macros/shared
+++ b/macros/shared
@@ -282,3 +282,8 @@ CROSS_COMPILATION_CONF_EOF\
 %force_disable_rpath \
   sed -i 's|^hardcode_libdir_flag_spec=.*|hardcode_libdir_flag_spec=""|g' libtool \
   sed -i 's|^runpath_var=LD_RUN_PATH|runpath_var=DIE_RPATH_DIE|g' libtool
+
+# By default, find-debuginfo comes from /usr/bin, and adds the tools there to
+# the path ahead of any other directories. To force it to use the target-specific
+# binutils programs, point to the symlink in the debuginfo override path instead.
+%__find_debuginfo /usr/%{_cross_target}/debuginfo/bin/find-debuginfo


### PR DESCRIPTION
**Issue number:**
N/A


**Description of changes:**
This fixes a regression where `find-debuginfo` now prefers `objcopy` in `/usr/bin` rather than the target-specific symlink placed ahead of it in $PATH. That happens because `find-debuginfo` now adds its own parent directory to $PATH in front of everything else.

Work around this by adding a `find-debuginfo` symlink to the debug helper directory, and override the macro so that `find-debuginfo` is called from that directory.

Also add a `readelf` symlink, since `find-debuginfo` calls it too.


**Testing done:**
Before, the output logs would show errors like this when building on `x86_64` for `aarch64`:
```
  #14 133.7 find-debuginfo: starting
  #14 133.8 Extracting debug info from 9 files
  #14 134.9 objcopy: Unable to recognise the format of the input file `/home/builder/rpmbuild/BUILDROOT/bottlerocket-settings-plugins-0.0-0.1727497932.29b947  0bc.br1.x86_64/aarch64-bottlerocket-linux-gnu/sys-root/usr/lib/settings-plugins/aws-dev/libsettings.so'
```

After, the errors go away since the target-specific `objcopy` is being used.



**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
