### PR TITLE
license-scan: remove license data from src dir before scanning

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -686,7 +686,7 @@ RUN \
   sdk-fetch hashes && \
   tar xf license-list-data-${SPDXVER}.tar.gz license-list-data-${SPDXVER}/json/details && \
   rm license-list-data-${SPDXVER}.tar.gz && \
-  mv license-list-data-${SPDXVER} license-list-data
+  mv license-list-data-${SPDXVER} /home/builder/license-list-data
 
 COPY --from=rust-sources /license-scan /home/builder/license-scan
 RUN cargo build --release --locked
@@ -758,7 +758,7 @@ COPY --chown=0:0 --from=sdk-license-scan \
   /usr/libexec/tools/
 
 COPY --chown=0:0 --from=sdk-license-scan \
-  /home/builder/license-scan/license-list-data/json/details \
+  /home/builder/license-list-data/json/details \
   /usr/libexec/tools/spdx-data
 
 COPY --chown=1000:1000 --from=sdk-cargo-deny \


### PR DESCRIPTION
**Description of changes:**
Because `license-scan` has `publish = false` in its Cargo.toml file, it used to refrain from scanning and attributing its own source directory.

We are planning to publish `bottlerocket-license-scan` to crates.io and so have unset `publish` in the crate. This has caused the SDK build to fail, because there happen to be extraneous licenses present in the license-scan tool's source directory when it is scanned.

This change removes those files before the scan begins.


**Testing done:**
* [x] SDK build


**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
