### PR TITLE
buildroot: enable libstdc++ shared libraries

### DIFF
--- a/patches/buildroot/0004-build-gcc-with-TOOLS_DIR-and-SYSROOT_DIR.patch
+++ b/patches/buildroot/0004-build-gcc-with-TOOLS_DIR-and-SYSROOT_DIR.patch
@@ -84,7 +84,7 @@ index aa883beb7b..0f61ff0df1 100644
 -else
 -HOST_GCC_FINAL_CONF_OPTS += --enable-shared
 +ifeq (y,y)
-+HOST_GCC_FINAL_CONF_OPTS += --enable-shared=libgcc
++HOST_GCC_FINAL_CONF_OPTS += --enable-shared=libgcc,libstdc++
  endif
  
  ifeq ($(BR2_GCC_ENABLE_OPENMP),y)


### PR DESCRIPTION
**Issue number:**
Fixes #215


**Description of changes:**
Enable libstdc++ shared libraries in addition to libgcc.

The static library doesn't work for the downstream use case of NVIDIA DCGM, which needs shared linking in order for plugins to work.

The context above the changed lines in the patch mentions that this can confuse static linking, but in my testing I didn't observe any confusion.

**Testing done:**
Built x86_64 and aarch64 core kits and AMIs on both architectures.

`libstdc++.so` is included in the SDK:
```
bash-5.2$ find /*-bottlerocket-linux-*/sys-root/usr/lib -name 'libstdc++*.so*'
/aarch64-bottlerocket-linux-gnu/sys-root/usr/lib/libstdc++.so.6.0.29
/aarch64-bottlerocket-linux-gnu/sys-root/usr/lib/libstdc++.so
/aarch64-bottlerocket-linux-gnu/sys-root/usr/lib/libstdc++.so.6
/aarch64-bottlerocket-linux-musl/sys-root/usr/lib/libstdc++.so.6.0.29
/aarch64-bottlerocket-linux-musl/sys-root/usr/lib/libstdc++.so
/aarch64-bottlerocket-linux-musl/sys-root/usr/lib/libstdc++.so.6
/x86_64-bottlerocket-linux-gnu/sys-root/usr/lib/libstdc++.so.6.0.29
/x86_64-bottlerocket-linux-gnu/sys-root/usr/lib/libstdc++.so
/x86_64-bottlerocket-linux-gnu/sys-root/usr/lib/libstdc++.so.6
/x86_64-bottlerocket-linux-musl/sys-root/usr/lib/libstdc++.so.6.0.29
/x86_64-bottlerocket-linux-musl/sys-root/usr/lib/libstdc++.so
/x86_64-bottlerocket-linux-musl/sys-root/usr/lib/libstdc++.so.6
```

@ndbaker1 confirmed that this resolved the issue with the DCGM build.


**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
