### PR TITLE
Bump aws-lc to 2.0.17

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -542,7 +542,7 @@ ENV CGO_LDFLAGS="${LDFLAGS}"
 
 ENV GO111MODULE="auto"
 
-ENV AWS_LC_FIPS_VER="2.0.9"
+ENV AWS_LC_FIPS_VER="2.0.17"
 
 USER root
 RUN dnf -y install golang

--- a/hashes/aws-lc
+++ b/hashes/aws-lc
@@ -1,2 +1,2 @@
-# https://github.com/aws/aws-lc/archive/refs/tags/AWS-LC-FIPS-2.0.9.tar.gz
-SHA512 (AWS-LC-FIPS-2.0.9.tar.gz) = 08481e8743b49d4461567c397d3d07e74845722176cc910a2ee08b9996f44cdc4f73569ece555f11d5ae6afb6de99452646057e8c3c6753d0a0f7e0c53615a32
+# https://github.com/aws/aws-lc/archive/refs/tags/AWS-LC-FIPS-2.0.17.tar.gz
+SHA512 (AWS-LC-FIPS-2.0.17.tar.gz) = acb61f71d4039112ab027db56a9b5b1f9b272d41bd014cb733a71f365db13a2ade4ecf86d988900b2f7c8429086caf379a59803bae3c7a00111da0b72b357a2a


### PR DESCRIPTION
**Issue number:**
N / A


**Description of changes:**
Bump `aws-lc` to 2.0.17


**Testing done:**

- [X] SDK builds
- [x] Launched aws-k8s-1.30 AMI and joins cluster
- [x] Launched aws-ecs-2 AMI and joins cluster


**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
