### PR TITLE
Revert "build: update base image to Fedora 40"

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM public.ecr.aws/docker/library/fedora:40 as base
+FROM public.ecr.aws/docker/library/fedora:39 as base
 
 # Everything we need to build our SDK and packages.
 RUN \


### PR DESCRIPTION
**Issue number:**
Fixes #226.


**Description of changes:**
This reverts commit 7303cb6a1b01853c67e7de85e8624a1c19d970fa.

The upgrade from jq 1.6 to 1.7 is causing trouble downstream, since Twoliter currently depends on the formerly-deprecated, now-removed `jq --argfile` option.

Revert back to Fedora 39 for now.


**Testing done:**
Built and tested as part of other recent changes.


**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
