### PR TITLE
go: build AWS-LC for glibc and musl

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -598,39 +598,87 @@ COPY ./helpers/aws-lc/* .
 
 # =^..^=   =^..^=   =^..^=   =^..^=   =^..^=   =^..^=   =^..^=   =^..^=   =^..^=
 
-FROM sdk-go-1.23-prep as sdk-go-1.23-aws-lc-x86_64
+FROM sdk-go-1.23-prep as sdk-go-1.23-aws-lc-gnu-x86_64
 ENV ARCH="x86_64"
-RUN ./build-aws-lc.sh --arch="${ARCH}" --go-dir="${HOME}/sdk-go"
+ENV LIBC="gnu"
+ENV TARGET="${ARCH}-bottlerocket-linux-${LIBC}"
+RUN ./build-aws-lc.sh --arch="${ARCH}" --target="${TARGET}" --go-dir="${HOME}/sdk-go"
 
 # =^..^=   =^..^=   =^..^=   =^..^=   =^..^=   =^..^=   =^..^=   =^..^=   =^..^=
 
-FROM sdk-go-1.23-prep as sdk-go-1.23-aws-lc-aarch64
+FROM sdk-go-1.23-prep as sdk-go-1.23-aws-lc-gnu-aarch64
 ENV ARCH="aarch64"
-RUN ./build-aws-lc.sh --arch="${ARCH}" --go-dir="${HOME}/sdk-go"
+ENV LIBC="gnu"
+ENV TARGET="${ARCH}-bottlerocket-linux-${LIBC}"
+RUN ./build-aws-lc.sh --arch="${ARCH}" --target="${TARGET}" --go-dir="${HOME}/sdk-go"
 
 # =^..^=   =^..^=   =^..^=   =^..^=   =^..^=   =^..^=   =^..^=   =^..^=   =^..^=
 
-FROM sdk-go-1.22-prep as sdk-go-1.22-aws-lc-x86_64
+FROM sdk-go-1.23-prep as sdk-go-1.23-aws-lc-musl-x86_64
 ENV ARCH="x86_64"
-RUN ./build-aws-lc.sh --arch="${ARCH}" --go-dir="${HOME}/sdk-go"
+ENV LIBC="musl"
+ENV TARGET="${ARCH}-bottlerocket-linux-${LIBC}"
+RUN ./build-aws-lc.sh --arch="${ARCH}" --target="${TARGET}" --go-dir="${HOME}/sdk-go"
 
 # =^..^=   =^..^=   =^..^=   =^..^=   =^..^=   =^..^=   =^..^=   =^..^=   =^..^=
 
-FROM sdk-go-1.22-prep as sdk-go-1.22-aws-lc-aarch64
+FROM sdk-go-1.23-prep as sdk-go-1.23-aws-lc-musl-aarch64
 ENV ARCH="aarch64"
-RUN ./build-aws-lc.sh --arch="${ARCH}" --go-dir="${HOME}/sdk-go"
+ENV LIBC="musl"
+ENV TARGET="${ARCH}-bottlerocket-linux-${LIBC}"
+RUN ./build-aws-lc.sh --arch="${ARCH}" --target="${TARGET}" --go-dir="${HOME}/sdk-go"
+
+# =^..^=   =^..^=   =^..^=   =^..^=   =^..^=   =^..^=   =^..^=   =^..^=   =^..^=
+
+FROM sdk-go-1.22-prep as sdk-go-1.22-aws-lc-gnu-x86_64
+ENV ARCH="x86_64"
+ENV LIBC="gnu"
+ENV TARGET="${ARCH}-bottlerocket-linux-${LIBC}"
+RUN ./build-aws-lc.sh --arch="${ARCH}" --target="${TARGET}" --go-dir="${HOME}/sdk-go"
+
+# =^..^=   =^..^=   =^..^=   =^..^=   =^..^=   =^..^=   =^..^=   =^..^=   =^..^=
+
+FROM sdk-go-1.22-prep as sdk-go-1.22-aws-lc-gnu-aarch64
+ENV ARCH="aarch64"
+ENV LIBC="gnu"
+ENV TARGET="${ARCH}-bottlerocket-linux-${LIBC}"
+RUN ./build-aws-lc.sh --arch="${ARCH}" --target="${TARGET}" --go-dir="${HOME}/sdk-go"
+
+# =^..^=   =^..^=   =^..^=   =^..^=   =^..^=   =^..^=   =^..^=   =^..^=   =^..^=
+
+FROM sdk-go-1.22-prep as sdk-go-1.22-aws-lc-musl-x86_64
+ENV ARCH="x86_64"
+ENV LIBC="musl"
+ENV TARGET="${ARCH}-bottlerocket-linux-${LIBC}"
+RUN ./build-aws-lc.sh --arch="${ARCH}" --target="${TARGET}" --go-dir="${HOME}/sdk-go"
+
+# =^..^=   =^..^=   =^..^=   =^..^=   =^..^=   =^..^=   =^..^=   =^..^=   =^..^=
+
+FROM sdk-go-1.22-prep as sdk-go-1.22-aws-lc-musl-aarch64
+ENV ARCH="aarch64"
+ENV LIBC="musl"
+ENV TARGET="${ARCH}-bottlerocket-linux-${LIBC}"
+RUN ./build-aws-lc.sh --arch="${ARCH}" --target="${TARGET}" --go-dir="${HOME}/sdk-go"
 
 # =^..^=   =^..^=   =^..^=   =^..^=   =^..^=   =^..^=   =^..^=   =^..^=   =^..^=
 
 FROM sdk-go-1.23-prep as sdk-go-1.23
 
-COPY --from=sdk-go-1.23-aws-lc-x86_64 \
+COPY --from=sdk-go-1.23-aws-lc-gnu-x86_64 \
   /home/builder/aws-lc/build/goboringcrypto_linux_amd64.syso \
   /home/builder/sdk-go/src/crypto/internal/boring/syso/goboringcrypto_linux_amd64.syso
 
-COPY --from=sdk-go-1.23-aws-lc-aarch64 \
+COPY --from=sdk-go-1.23-aws-lc-gnu-aarch64 \
   /home/builder/aws-lc/build/goboringcrypto_linux_arm64.syso \
   /home/builder/sdk-go/src/crypto/internal/boring/syso/goboringcrypto_linux_arm64.syso
+
+COPY --from=sdk-go-1.23-aws-lc-musl-x86_64 \
+  /home/builder/aws-lc/build/goboringcrypto_linux_amd64.syso \
+  /home/builder/sdk-go/src/crypto/internal/boring/syso/goboringcrypto_linux_musl_amd64.syso
+
+COPY --from=sdk-go-1.23-aws-lc-musl-aarch64 \
+  /home/builder/aws-lc/build/goboringcrypto_linux_arm64.syso \
+  /home/builder/sdk-go/src/crypto/internal/boring/syso/goboringcrypto_linux_musl_arm64.syso
 
 COPY ./helpers/go/* ./
 
@@ -641,13 +689,21 @@ RUN ./build-go.sh --go-version=${GO123VER}
 
 FROM sdk-go-1.22-prep as sdk-go-1.22
 
-COPY --from=sdk-go-1.22-aws-lc-x86_64 \
+COPY --from=sdk-go-1.22-aws-lc-gnu-x86_64 \
   /home/builder/aws-lc/build/goboringcrypto_linux_amd64.syso \
   /home/builder/sdk-go/src/crypto/internal/boring/syso/goboringcrypto_linux_amd64.syso
 
-COPY --from=sdk-go-1.22-aws-lc-aarch64 \
+COPY --from=sdk-go-1.22-aws-lc-gnu-aarch64 \
   /home/builder/aws-lc/build/goboringcrypto_linux_arm64.syso \
   /home/builder/sdk-go/src/crypto/internal/boring/syso/goboringcrypto_linux_arm64.syso
+
+COPY --from=sdk-go-1.22-aws-lc-musl-x86_64 \
+  /home/builder/aws-lc/build/goboringcrypto_linux_amd64.syso \
+  /home/builder/sdk-go/src/crypto/internal/boring/syso/goboringcrypto_linux_musl_amd64.syso
+
+COPY --from=sdk-go-1.22-aws-lc-musl-aarch64 \
+  /home/builder/aws-lc/build/goboringcrypto_linux_arm64.syso \
+  /home/builder/sdk-go/src/crypto/internal/boring/syso/goboringcrypto_linux_musl_arm64.syso
 
 COPY ./helpers/go/* ./
 
@@ -1253,6 +1309,18 @@ COPY --chown=0:0 --from=sdk-go-1.22 \
   /home/builder/sdk-go/licenses/ \
   /usr/share/licenses/go-1.22/
 
+# Create Go trees for the different glibc and musl builds of the AWS-LC syso.
+# Sync timestamps to avoid rebuilds of the Go standard library.
+RUN \
+  for v in 1.22 1.23 ; do \
+    find /usr/libexec/go-${v} -type f -exec touch -r /usr/libexec/go-${v}/bin/go {} \+ && \
+    rsync -aq --link-dest=/usr/libexec/go-${v}/ /usr/libexec/go-${v}{,-musl}/ && \
+    rm /usr/libexec/go-${v}/src/crypto/internal/boring/syso/goboringcrypto_linux_musl_{arm,amd}64.syso && \
+    rm /usr/libexec/go-${v}-musl/src/crypto/internal/boring/syso/goboringcrypto_linux_{arm,amd}64.syso && \
+    mv /usr/libexec/go-${v}-musl/src/crypto/internal/boring/syso/goboringcrypto_linux_{musl_,}amd64.syso && \
+    mv /usr/libexec/go-${v}-musl/src/crypto/internal/boring/syso/goboringcrypto_linux_{musl_,}arm64.syso ; \
+  done
+
 # "sdk-rust-tools" has our attribution generation and license scan tools.
 COPY --chown=0:0 --from=sdk-rust-tools /usr/libexec/tools/ /usr/libexec/tools/
 COPY --chown=0:0 --from=sdk-rust-tools /usr/share/licenses/bottlerocket-license-scan/ /usr/share/licenses/bottlerocket-license-scan/
@@ -1363,11 +1431,6 @@ RUN \
 COPY ./wrappers/go/go /usr/bin/go
 COPY ./wrappers/go/gofmt /usr/bin/gofmt
 COPY ./wrappers/go/gofips /usr/bin/gofips
-
-# Add Go programs to $PATH and sync timestamps to avoid rebuilds.
-RUN \
-  find /usr/libexec/go-1.23 -type f -exec touch -r /usr/libexec/go-1.23/bin/go {} \+ && \
-  find /usr/libexec/go-1.22 -type f -exec touch -r /usr/libexec/go-1.22/bin/go {} \+
 
 # Strip and add tools to the path.
 RUN \

--- a/configs/aws-lc/aarch64-bottlerocket-linux-musl.toolchain.cmake
+++ b/configs/aws-lc/aarch64-bottlerocket-linux-musl.toolchain.cmake
@@ -1,0 +1,13 @@
+set(CMAKE_SYSTEM_NAME Linux)
+set(CMAKE_SYSTEM_PROCESSOR aarch64)
+
+set(CMAKE_SYSROOT /aarch64-bottlerocket-linux-musl/sys-root)
+set(CMAKE_C_COMPILER aarch64-bottlerocket-linux-musl-gcc)
+set(CMAKE_C_COMPILER_TARGET aarch64-bottlerocket-linux-musl)
+set(CMAKE_CXX_COMPILER aarch64-bottlerocket-linux-musl-g++)
+set(CMAKE_CXX_COMPILER_TARGET aarch64-bottlerocket-linux-musl)
+
+set(CMAKE_FIND_ROOT_PATH_MODE_PROGRAM NEVER)
+set(CMAKE_FIND_ROOT_PATH_MODE_LIBRARY ONLY)
+set(CMAKE_FIND_ROOT_PATH_MODE_INCLUDE ONLY)
+set(CMAKE_FIND_ROOT_PATH_MODE_PACKAGE ONLY)

--- a/configs/aws-lc/x86_64-bottlerocket-linux-musl.toolchain.cmake
+++ b/configs/aws-lc/x86_64-bottlerocket-linux-musl.toolchain.cmake
@@ -1,0 +1,13 @@
+set(CMAKE_SYSTEM_NAME Linux)
+set(CMAKE_SYSTEM_PROCESSOR x86_64)
+
+set(CMAKE_SYSROOT /x86_64-bottlerocket-linux-musl/sys-root)
+set(CMAKE_C_COMPILER x86_64-bottlerocket-linux-musl-gcc)
+set(CMAKE_C_COMPILER_TARGET x86_64-bottlerocket-linux-musl)
+set(CMAKE_CXX_COMPILER x86_64-bottlerocket-linux-musl-g++)
+set(CMAKE_CXX_COMPILER_TARGET x86_64-bottlerocket-linux-musl)
+
+set(CMAKE_FIND_ROOT_PATH_MODE_PROGRAM NEVER)
+set(CMAKE_FIND_ROOT_PATH_MODE_LIBRARY ONLY)
+set(CMAKE_FIND_ROOT_PATH_MODE_INCLUDE ONLY)
+set(CMAKE_FIND_ROOT_PATH_MODE_PACKAGE ONLY)

--- a/helpers/aws-lc/build-aws-lc.sh
+++ b/helpers/aws-lc/build-aws-lc.sh
@@ -8,13 +8,14 @@ for opt in "$@"; do
    optarg="$(expr "${opt}" : '[^=]*=\(.*\)')"
    case "${opt}" in
       --arch=*) ARCH="${optarg}" ;;
+      --target=*) TARGET="${optarg}" ;;
       --go-dir=*) GODIR="${optarg}" ;;
    esac
 done
 
 ARCH="${ARCH:?}"
 GODIR="${GODIR:?}"
-TARGET="${ARCH}-bottlerocket-linux-gnu"
+TARGET="${TARGET:?}"
 
 # Some of the AWS-LC sources are built with `-O0`. This is not compatible with
 # `-Wp,-D_FORTIFY_SOURCE=2`, which needs at least `-O2`. Add `-DGOBORING` to

--- a/macros/shared
+++ b/macros/shared
@@ -225,6 +225,7 @@ CROSS_CMAKE_TOOLCHAIN_EOF\
   GOPATH="${PWD}/GOPATH" ; export GOPATH ; \
   GOOS="%{_cross_go_os}" ; export GOOS ; \
   GOARCH="%{_cross_go_arch}" ; export GOARCH ; \
+  GOLIBC="%2" ; export GOLIBC ; \
   CC="%1-gcc" ; export CC ; \
   CC_FOR_TARGET="%1-gcc" ; export CC_FOR_TARGET ; \
   CC_FOR_%{_cross_go_os}_%{_cross_go_arch}="%1-gcc" ; export CC_FOR_%{_cross_go_os}_%{_cross_go_arch} ; \
@@ -239,7 +240,7 @@ CROSS_CMAKE_TOOLCHAIN_EOF\
   PKG_CONFIG_ALLOW_CROSS=1 ; export PKG_CONFIG_ALLOW_CROSS ; \
   GOFLAGS="-mod=vendor -a -buildmode=pie"; export GOFLAGS ; \
   GOLDFLAGS_INT="-compressdwarf=false -linkmode=external" ; export GOLDFLAGS_INT ; \
-  GOLDFLAGS_EXT="%{expand:%%%2}" ; export GOLDFLAGS_EXT ; \
+  GOLDFLAGS_EXT="%{expand:%%%3}" ; export GOLDFLAGS_EXT ; \
   GOLDFLAGS="${GOLDFLAGS_INT} -extldflags '${GOLDFLAGS_EXT}'" ; export GOLDFLAGS ; \
   GOPROXY="off"; export GOPROXY ; \
   GOSUMDB="off"; export GOSUMDB ; \
@@ -249,10 +250,10 @@ CROSS_CMAKE_TOOLCHAIN_EOF\
 %_cross_go_extldflags_static %{_cross_ldflags} -static-pie
 
 %set_cross_go_flags \
-  %set_cross_go_env %{_cross_target} _cross_go_extldflags
+  %set_cross_go_env %{_cross_target} gnu _cross_go_extldflags
 
 %set_cross_go_flags_static \
-  %set_cross_go_env %{_cross_triple}-musl _cross_go_extldflags_static
+  %set_cross_go_env %{_cross_triple}-musl musl _cross_go_extldflags_static
 
 %cross_go_setup() \
   mkdir -p GOPATH/src/%2 ; \

--- a/wrappers/go/go
+++ b/wrappers/go/go
@@ -10,4 +10,9 @@ if [ -n "${GO_VERSION:-}" ] ; then
   GO_MAJOR="${GO_VERSION%.*}"
 fi
 
+# prefer the musl flavor if GOLIBC indicates that we should
+if [ "${GOLIBC:-}" = "musl" ] ; then
+  GO_MAJOR+="-musl"
+fi
+
 exec /usr/libexec/go-"${GO_MAJOR}"/bin/go "${@}"

--- a/wrappers/go/gofips
+++ b/wrappers/go/gofips
@@ -10,5 +10,10 @@ if [ -n "${GO_VERSION:-}" ] ; then
   GO_MAJOR="${GO_VERSION%.*}"
 fi
 
+# prefer the musl flavor if GOLIBC indicates that we should
+if [ "${GOLIBC:-}" = "musl" ] ; then
+  GO_MAJOR+="-musl"
+fi
+
 export GOEXPERIMENT=boringcrypto
 exec /usr/libexec/go-"${GO_MAJOR}"/bin/go "${@}"

--- a/wrappers/go/gofmt
+++ b/wrappers/go/gofmt
@@ -10,4 +10,9 @@ if [ -n "${GO_VERSION:-}" ] ; then
   GO_MAJOR="${GO_VERSION%.*}"
 fi
 
+# prefer the musl flavor if GOLIBC indicates that we should
+if [ "${GOLIBC:-}" = "musl" ] ; then
+  GO_MAJOR+="-musl"
+fi
+
 exec /usr/libexec/go-"${GO_MAJOR}"/bin/gofmt "${@}"


### PR DESCRIPTION
**Issue number:**
Fixes #225


**Description of changes:**
Set up Go roots that differ based on the C library that the AWS-LC syso was linked against.

Fix the "set_cross_go_flags" and "set_cross_go_flags_static" macros to set GOLIBC. One of these macros is expected to be invoked prior to any Go build.

Update the Go wrapper scripts to check the value of "GOLIBC" in the environment and pick the corresponding Go root.


**Testing done:**
Built with other recent changes. This fixes the build failure for the static FIPS build of `amazon-ssm-agent`, which is used for the "ECS Exec" feature.


**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
