### PR TITLE
macros: add %_cross_buildsrcdir

### DIFF
--- a/macros/shared
+++ b/macros/shared
@@ -23,6 +23,7 @@
 %_cross_ldflags -Wl,-z,relro -Wl,-z,now -Wl,-Bsymbolic-functions
 %_cross_c_link_args '-Wl,-z,relro', '-Wl,-z,now', '-Wl,-Bsymbolic-functions'
 
+%_cross_buildsrcdir %{_topdir}/BUILD/sources
 %_cross_bootdir /boot
 %_cross_bootconfigdir %{_cross_bootdir}/boot-config.d
 %_cross_lib lib


### PR DESCRIPTION
**Issue number:**
Related: #238

**Description of changes:**
Twoliter mounts sources for the current workspace into the SDK build environment at `/home/builder/rpmbuild/BUILD/sources`, which packages can refer to via the %_builddir macro - e.g. "%{_builddir}/sources" - to avoid hard-coding assumptions about the SDK environment, such as the user account that executes the build.

In RPM 4.20, the %_builddir macro now points to a package-specific directory rather than the top-level build directory, which breaks this approach.

Define %_cross_buildsrcdir as a replacement for %_builddir which will always point to the path in the SDK where Twoliter mounts the sources from the current workspace.


**Testing done:**
Verified that the macro has the expected value.
```
❯ docker run -it --rm bottlerocket-sdk:v0.50.0-56e5548d-arm64 bash
bash-5.2$ cp /usr/lib/rpm/platform/aarch64-bottlerocket/macros .rpmmacros
bash-5.2$ rpm --eval %_cross_buildsrcdir
/home/builder/rpmbuild/BUILD/sources
```


**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
