### PR TITLE
macros: add compat symlink for workspace sources

### DIFF
--- a/macros/shared
+++ b/macros/shared
@@ -325,6 +325,14 @@ CROSS_CMAKE_TOOLCHAIN_EOF\
   %{?cross_check_fips:%{__cross_check_fips_cmd}} \
   %cross_generate_attribution
 
+# Link "sources" from the new per-package build directory to the old location.
+%__spec_prep_pre \
+  %{___build_pre} \
+  if [ \"%{_cross_buildsrcdir}\" != \"%{builddir}/sources\" ]; then\
+    ln -srnf \"%{_cross_buildsrcdir}\" \"%{builddir}/sources\"\
+  fi\
+  %{nil}
+
 %source_date_epoch_from_changelog 0
 
 # Forcefully prevent libtool from embedding an explicit rpath during linking,


### PR DESCRIPTION
**Issue number:**
Related: #239


**Description of changes:**
This is a better version of the initial fix in #239 - rather than expecting downstream packages to switch to the new macro, create a symlink to the old location for workspace sources in the per-package `%{builddir}`.

The old location is widely used by the core kit and downstream variant builds, and breaking it would create unnecessary friction for adopting an updated SDK.


**Testing done:**
Built the core kit using an SDK with this change, plus the switch to a Fedora 41 base image with RPM 4.20.


**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
