### PR TITLE
build: update base image to Fedora 41

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,8 @@
-FROM public.ecr.aws/docker/library/fedora:39 AS base
+FROM public.ecr.aws/docker/library/fedora:41 AS base
 
 # Everything we need to build our SDK and packages.
 RUN \
+  dnf config-manager setopt fedora-cisco-openh264.enabled=0 && \
   dnf makecache && \
   dnf -y update && \
   dnf -y install --setopt=install_weak_deps=False \
@@ -28,6 +29,7 @@ RUN \
     meson \
     openssl \
     openssl-devel \
+    openssl-devel-engine \
     p11-kit-devel \
     perl-ExtUtils-MakeMaker \
     perl-FindBin \
@@ -37,9 +39,6 @@ RUN \
     rsync \
     wget \
     which \
-  && \
-  dnf config-manager --set-disabled \
-    fedora-cisco-openh264 \
   && \
   useradd builder
 COPY ./sdk-fetch /usr/local/bin
@@ -425,9 +424,9 @@ RUN \
   sdk-fetch /home/builder/hashes && \
   rpm2cpio "grub2-${GRUB_VER}.src.rpm" \
   | cpio -iu \
-     "grub-${GRUB_VER%%-*}.tar.xz" \
-      bootstrap bootstrap.conf gitignore \
-      "gnulib-*.tar.gz" "*.patch" && \
+     "./grub-${GRUB_VER%%-*}.tar.xz" \
+      ./bootstrap ./bootstrap.conf ./gitignore \
+      "./gnulib-*.tar.gz" "./*.patch" && \
   rm "grub2-${GRUB_VER}.src.rpm" && \
   mkdir "grub-${GRUB_VER}" && \
   cd "grub-${GRUB_VER}" && \
@@ -561,7 +560,7 @@ USER builder
 WORKDIR /home/builder/sdk-go
 
 COPY ./hashes/go-${GOMAJOR} /home/builder/hashes-go
-COPY ./helpers/go/* ./
+COPY ./helpers/go/prep-go.sh ./
 COPY ./patches/go-${GOMAJOR} /home/builder/patches-go
 
 COPY ./hashes/aws-lc /home/builder/hashes-aws-lc
@@ -584,7 +583,7 @@ USER builder
 WORKDIR /home/builder/sdk-go
 
 COPY ./hashes/go-${GOMAJOR} /home/builder/hashes-go
-COPY ./helpers/go/* ./
+COPY ./helpers/go/prep-go.sh ./
 COPY ./patches/go-${GOMAJOR} /home/builder/patches-go
 
 COPY ./hashes/aws-lc /home/builder/hashes-aws-lc
@@ -680,7 +679,7 @@ COPY --from=sdk-go-1.23-aws-lc-musl-aarch64 \
   /home/builder/aws-lc/build/goboringcrypto_linux_arm64.syso \
   /home/builder/sdk-go/src/crypto/internal/boring/syso/goboringcrypto_linux_musl_arm64.syso
 
-COPY ./helpers/go/* ./
+COPY ./helpers/go/build-go.sh ./
 
 # Build Go - finally!
 RUN ./build-go.sh --go-version=${GO123VER}
@@ -705,7 +704,7 @@ COPY --from=sdk-go-1.22-aws-lc-musl-aarch64 \
   /home/builder/aws-lc/build/goboringcrypto_linux_arm64.syso \
   /home/builder/sdk-go/src/crypto/internal/boring/syso/goboringcrypto_linux_musl_arm64.syso
 
-COPY ./helpers/go/* ./
+COPY ./helpers/go/build-go.sh ./
 
 # Build Go - finally!
 RUN ./build-go.sh --go-version=${GO122VER}
@@ -956,7 +955,6 @@ RUN \
     createrepo_c \
     dosfstools \
     e2fsprogs \
-    efitools \
     erofs-utils \
     flatbuffers-compiler \
     gdisk \
@@ -1265,8 +1263,16 @@ RUN \
   ln -sr /aarch64-bottlerocket-linux-gnu/sys-root/usr/share/licenses /usr/share/licenses/bottlerocket-sdk-gnu-aarch64 && \
   ln -sr /aarch64-bottlerocket-linux-musl/sys-root/usr/share/licenses /usr/share/licenses/bottlerocket-sdk-musl-aarch64
 
+# Forcibly undefine the auto_set_build_flags macros, since it no longer works to
+# undefine it when rpmbuild is invoked (as of RPM 4.20).
+RUN \
+  sed -i '/%_auto_set_build_flags 1/d' \
+    /usr/lib/rpm/redhat/macros
+
 # Reset permissions for `builder`.
-RUN chown builder:builder -R /home/builder
+RUN \
+  mkdir -p /home/builder && \
+  chown builder:builder -R /home/builder
 
 USER builder
 RUN rpmdev-setuptree

--- a/patches/go-1.22/0003-Default-to-ld.bfd-on-ARM64.patch
+++ b/patches/go-1.22/0003-Default-to-ld.bfd-on-ARM64.patch
@@ -1,0 +1,46 @@
+From 46ec67413008607e2150e3395668e54e538c5b6b Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Alejandro=20S=C3=A1ez?= <asm@redhat.com>
+Date: Wed, 19 Jun 2024 10:18:58 +0200
+Subject: [PATCH] Default to ld.bfd on ARM64
+
+---
+ src/cmd/link/internal/ld/lib.go | 20 +++++++-------------
+ 1 file changed, 7 insertions(+), 13 deletions(-)
+
+diff --git a/src/cmd/link/internal/ld/lib.go b/src/cmd/link/internal/ld/lib.go
+index eab74dc328..b401f58727 100644
+--- a/src/cmd/link/internal/ld/lib.go
++++ b/src/cmd/link/internal/ld/lib.go
+@@ -1620,22 +1620,16 @@ func (ctxt *Link) hostlink() {
+ 		}
+ 
+ 		if ctxt.Arch.InFamily(sys.ARM64) && buildcfg.GOOS == "linux" {
+-			// On ARM64, the GNU linker will fail with
+-			// -znocopyreloc if it thinks a COPY relocation is
+-			// required. Switch to gold.
+-			// https://sourceware.org/bugzilla/show_bug.cgi?id=19962
+-			// https://go.dev/issue/22040
+-			altLinker = "gold"
+-
+-			// If gold is not installed, gcc will silently switch
+-			// back to ld.bfd. So we parse the version information
+-			// and provide a useful error if gold is missing.
++			// Use ld.bfd as the default linker
++			altLinker = "bfd"
++
++			// Provide a useful error if ld.bfd is missing
+ 			name, args := flagExtld[0], flagExtld[1:]
+-			args = append(args, "-fuse-ld=gold", "-Wl,--version")
++			args = append(args, "-fuse-ld=bfd", "-Wl,--version")
+ 			cmd := exec.Command(name, args...)
+ 			if out, err := cmd.CombinedOutput(); err == nil {
+-				if !bytes.Contains(out, []byte("GNU gold")) {
+-					log.Fatalf("ARM64 external linker must be gold (issue #15696, 22040), but is not: %s", out)
++				if !bytes.Contains(out, []byte("GNU ld")) {
++					log.Fatalf("ARM64 external linker must be ld.bfd, but is not: %s", out)
+ 				}
+ 			}
+ 		}
+-- 
+2.45.1
+

--- a/patches/go-1.23/0003-Default-to-ld.bfd-on-ARM64.patch
+++ b/patches/go-1.23/0003-Default-to-ld.bfd-on-ARM64.patch
@@ -1,0 +1,46 @@
+From 46ec67413008607e2150e3395668e54e538c5b6b Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Alejandro=20S=C3=A1ez?= <asm@redhat.com>
+Date: Wed, 19 Jun 2024 10:18:58 +0200
+Subject: [PATCH] Default to ld.bfd on ARM64
+
+---
+ src/cmd/link/internal/ld/lib.go | 20 +++++++-------------
+ 1 file changed, 7 insertions(+), 13 deletions(-)
+
+diff --git a/src/cmd/link/internal/ld/lib.go b/src/cmd/link/internal/ld/lib.go
+index eab74dc328..b401f58727 100644
+--- a/src/cmd/link/internal/ld/lib.go
++++ b/src/cmd/link/internal/ld/lib.go
+@@ -1620,22 +1620,16 @@ func (ctxt *Link) hostlink() {
+ 		}
+ 
+ 		if ctxt.Arch.InFamily(sys.ARM64) && buildcfg.GOOS == "linux" {
+-			// On ARM64, the GNU linker will fail with
+-			// -znocopyreloc if it thinks a COPY relocation is
+-			// required. Switch to gold.
+-			// https://sourceware.org/bugzilla/show_bug.cgi?id=19962
+-			// https://go.dev/issue/22040
+-			altLinker = "gold"
+-
+-			// If gold is not installed, gcc will silently switch
+-			// back to ld.bfd. So we parse the version information
+-			// and provide a useful error if gold is missing.
++			// Use ld.bfd as the default linker
++			altLinker = "bfd"
++
++			// Provide a useful error if ld.bfd is missing
+ 			name, args := flagExtld[0], flagExtld[1:]
+-			args = append(args, "-fuse-ld=gold", "-Wl,--version")
++			args = append(args, "-fuse-ld=bfd", "-Wl,--version")
+ 			cmd := exec.Command(name, args...)
+ 			if out, err := cmd.CombinedOutput(); err == nil {
+-				if !bytes.Contains(out, []byte("GNU gold")) {
+-					log.Fatalf("ARM64 external linker must be gold (issue #15696, 22040), but is not: %s", out)
++				if !bytes.Contains(out, []byte("GNU ld")) {
++					log.Fatalf("ARM64 external linker must be ld.bfd, but is not: %s", out)
+ 				}
+ 			}
+ 		}
+-- 
+2.45.1
+


### PR DESCRIPTION
**Issue number:**
Fixes: #238


**Description of changes:**
The largest breaking change from the Fedora 41 update is covered by #241, which is safe to merge independently from this, and therefore doesn't need to be reverted if this is reverted.

That leaves a bunch of minor changes:
* Deal with the behavior change in `rpm2cpio` from RPM 4.20: files are now prefixed with "./", and when extracting a subset of files, this prefix must be provided or no match will be found.
* Undefine %_auto_set_build_flags in the default macros, since it's no longer trivial to do so downstream, and they clash with the required build flags for cross-compiling.
* efitools is not used downstream and is no longer available in Fedora, so drop it.
* The OpenSSL ENGINE API headers are no longer installed by default, so add them back. They can be dropped again when we update the AWS SDK for C++ with a new-enough version of s2n, which is not yet available.
* The gold linker is no longer installed by default, so add a Go patch so that it's not preferred on aarch64.

**Testing done:**
Built kits and variants, albeit with some minor changes required downstream.


**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
