### PR TITLE
musl: add patches for CVE-2025-26519

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -212,6 +212,7 @@ USER builder
 
 WORKDIR /home/builder
 COPY ./hashes/musl ./hashes
+COPY ./patches/musl ./patches
 COPY ./helpers/musl/* ./
 
 ENV MUSLVER="1.2.4"
@@ -219,7 +220,10 @@ RUN \
   sdk-fetch hashes && \
   tar xf musl-${MUSLVER}.tar.gz && \
   rm musl-${MUSLVER}.tar.gz && \
-  mv musl-${MUSLVER} musl
+  mv musl-${MUSLVER} musl && \
+  cd musl && \
+  git init . && \
+  git apply --whitespace=nowarn ../patches/*.patch
 
 # =^..^=   =^..^=   =^..^=   =^..^=   =^..^=   =^..^=   =^..^=   =^..^=   =^..^=
 

--- a/patches/musl/0001-iconv-fix-erroneous-input-validation-in-EUC-KR-decod.patch
+++ b/patches/musl/0001-iconv-fix-erroneous-input-validation-in-EUC-KR-decod.patch
@@ -1,0 +1,38 @@
+From e5adcd97b5196e29991b524237381a0202a60659 Mon Sep 17 00:00:00 2001
+From: Rich Felker <dalias@aerifal.cx>
+Date: Sun, 9 Feb 2025 10:07:19 -0500
+Subject: [PATCH] iconv: fix erroneous input validation in EUC-KR decoder
+
+as a result of incorrect bounds checking on the lead byte being
+decoded, certain invalid inputs which should produce an encoding
+error, such as "\xc8\x41", instead produced out-of-bounds loads from
+the ksc table.
+
+in a worst case, the loaded value may not be a valid unicode scalar
+value, in which case, if the output encoding was UTF-8, wctomb would
+return (size_t)-1, causing an overflow in the output pointer and
+remaining buffer size which could clobber memory outside of the output
+buffer.
+
+bug report was submitted in private by Nick Wellnhofer on account of
+potential security implications.
+---
+ src/locale/iconv.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/src/locale/iconv.c b/src/locale/iconv.c
+index 9605c8e9..008c93f0 100644
+--- a/src/locale/iconv.c
++++ b/src/locale/iconv.c
+@@ -502,7 +502,7 @@ size_t iconv(iconv_t cd, char **restrict in, size_t *restrict inb, char **restri
+ 			if (c >= 93 || d >= 94) {
+ 				c += (0xa1-0x81);
+ 				d += 0xa1;
+-				if (c >= 93 || c>=0xc6-0x81 && d>0x52)
++				if (c > 0xc6-0x81 || c==0xc6-0x81 && d>0x52)
+ 					goto ilseq;
+ 				if (d-'A'<26) d = d-'A';
+ 				else if (d-'a'<26) d = d-'a'+26;
+-- 
+2.47.0
+

--- a/patches/musl/0002-iconv-harden-UTF-8-output-code-path-against-input-de.patch
+++ b/patches/musl/0002-iconv-harden-UTF-8-output-code-path-against-input-de.patch
@@ -1,0 +1,37 @@
+From c47ad25ea3b484e10326f933e927c0bc8cded3da Mon Sep 17 00:00:00 2001
+From: Rich Felker <dalias@aerifal.cx>
+Date: Wed, 12 Feb 2025 17:06:30 -0500
+Subject: [PATCH] iconv: harden UTF-8 output code path against input decoder
+ bugs
+
+the UTF-8 output code was written assuming an invariant that iconv's
+decoders only emit valid Unicode Scalar Values which wctomb can encode
+successfully, thereby always returning a value between 1 and 4.
+
+if this invariant is not satisfied, wctomb returns (size_t)-1, and the
+subsequent adjustments to the output buffer pointer and remaining
+output byte count overflow, moving the output position backwards,
+potentially past the beginning of the buffer, without storing any
+bytes.
+---
+ src/locale/iconv.c | 4 ++++
+ 1 file changed, 4 insertions(+)
+
+diff --git a/src/locale/iconv.c b/src/locale/iconv.c
+index 008c93f0..52178950 100644
+--- a/src/locale/iconv.c
++++ b/src/locale/iconv.c
+@@ -545,6 +545,10 @@ size_t iconv(iconv_t cd, char **restrict in, size_t *restrict inb, char **restri
+ 				if (*outb < k) goto toobig;
+ 				memcpy(*out, tmp, k);
+ 			} else k = wctomb_utf8(*out, c);
++			/* This failure condition should be unreachable, but
++			 * is included to prevent decoder bugs from translating
++			 * into advancement outside the output buffer range. */
++			if (k>4) goto ilseq;
+ 			*out += k;
+ 			*outb -= k;
+ 			break;
+-- 
+2.47.0
+


### PR DESCRIPTION
**Issue number:**
Fixes: [CVE-2025-26519](https://www.openwall.com/lists/musl/2025/02/13/1)


**Description of changes:**
Add patches per the advisory notice on [musl-libc.org](https://musl.libc.org/).


**Testing done:**
Built kits and variants. Static binaries like `apiclient` continue to work as expected.


**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
