### PR TITLE
update cargo-deny to 0.18.1

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -699,7 +699,7 @@ RUN cargo build --release --locked
 
 FROM sdk-cargo AS sdk-cargo-deny
 
-ENV DENYVER="0.16.1"
+ENV DENYVER="0.18.1"
 
 USER builder
 WORKDIR /home/builder

--- a/configs/cargo-deny/clarify.toml
+++ b/configs/cargo-deny/clarify.toml
@@ -28,7 +28,6 @@ license-files = [
     { path = "COPYING", hash = 0x278afbcf },
     { path = "LICENSE-APACHE", hash = 0x24b54f4b },
     { path = "LICENSE-MIT", hash = 0x462dee44 },
-    { path = "src/unicode/data/LICENSE-UNICODE", hash = 0x70f7339 },
 ]
 
 [clarify.cargo-deny]
@@ -174,6 +173,17 @@ license-files = [
     { path = "src/unicode_tables/LICENSE-UNICODE", hash = 0xa7f28b93 },
 ]
 
+[clarify.ring]
+expression = "Apache-2.0 AND MIT AND ISC"
+license-files = [
+    { path = "LICENSE", hash = 0xd99693a },
+    { path = "LICENSE-BoringSSL", hash = 0x8f795a3 },
+    { path = "LICENSE-other-bits", hash = 0x8b770de2 },
+    { path = "src/polyfill/once_cell/LICENSE-MIT", hash = 0x69371061 },
+    { path = "src/polyfill/once_cell/LICENSE-APACHE", hash = 0x24b54f4b },
+    { path = "third_party/fiat/LICENSE", hash = 0x931a8dd4 },
+]
+
 [clarify.rustsec]
 expression = "MIT OR Apache-2.0"
 license-files = [
@@ -198,6 +208,7 @@ license-files = [
 ]
 # skip files that contain the text of licenses
 skip-files = [
+    "src/text/exceptions/GPL-3.0-389-ds-base-exception",
     "src/text/exceptions/GPL-3.0-interface-exception",
     "src/text/exceptions/GPL-3.0-linking-exception",
     "src/text/exceptions/GPL-3.0-linking-source-exception",
@@ -362,11 +373,11 @@ license-files = [
 ]
 
 [clarify.unicode-ident]
-expression = "(MIT OR Apache-2.0) AND Unicode-DFS-2016"
+expression = "(MIT OR Apache-2.0) AND Unicode-3.0"
 license-files = [
     { path = "LICENSE-APACHE", hash = 0xb5518783 },
     { path = "LICENSE-MIT", hash = 0x386ca1bc },
-    { path = "LICENSE-UNICODE", hash = 0x9698cbbe },
+    { path = "LICENSE-UNICODE", hash = 0x3475d800 },
 ]
 
 [clarify.zstd-safe]

--- a/configs/cargo-deny/deny.toml
+++ b/configs/cargo-deny/deny.toml
@@ -9,7 +9,7 @@ allow = [
     "BSL-1.0",
     "ISC",
     "MIT",
-    "OpenSSL",
+    # "OpenSSL",
     "Unlicense",
     "Zlib",
 ]
@@ -17,14 +17,26 @@ allow = [
 exceptions = [
     { name = "webpki-roots", allow = ["MPL-2.0"] },
     { name = "target-lexicon", allow = ["Apache-2.0 WITH LLVM-exception"] },
-    { name = "unicode-ident", allow = ["MIT", "Apache-2.0", "Unicode-DFS-2016"] },
-]
-
-[[licenses.clarify]]
-name = "ring"
-expression = "MIT AND ISC AND OpenSSL"
-license-files = [
-    { path = "LICENSE", hash = 0xbd0eed23 },
+    { name = "unicode-ident", allow = ["MIT", "Apache-2.0", "Unicode-3.0"] },
+    { name = "icu_collections", allow = ["Unicode-3.0"] },
+    { name = "icu_locid", allow = ["Unicode-3.0"] },
+    { name = "icu_locid_transform", allow = ["Unicode-3.0"] },
+    { name = "icu_locid_transform_data", allow = ["Unicode-3.0"] },
+    { name = "icu_normalizer", allow = ["Unicode-3.0"] },
+    { name = "icu_normalizer_data", allow = ["Unicode-3.0"] },
+    { name = "icu_properties", allow = ["Unicode-3.0"] },
+    { name = "icu_properties_data", allow = ["Unicode-3.0"] },
+    { name = "icu_provider", allow = ["Unicode-3.0"] },
+    { name = "icu_provider_macros", allow = ["Unicode-3.0"] },
+    { name = "litemap", allow = ["Unicode-3.0"] },
+    { name = "tinystr", allow = ["Unicode-3.0"] },
+    { name = "writeable", allow = ["Unicode-3.0"] },
+    { name = "yoke", allow = ["Unicode-3.0"] },
+    { name = "yoke-derive", allow = ["Unicode-3.0"] },
+    { name = "zerofrom", allow = ["Unicode-3.0"] },
+    { name = "zerofrom-derive", allow = ["Unicode-3.0"] },
+    { name = "zerovec", allow = ["Unicode-3.0"] },
+    { name = "zerovec-derive", allow = ["Unicode-3.0"] },
 ]
 
 [bans]
@@ -33,12 +45,26 @@ multiple-versions = "deny"
 wildcards = "deny"
 
 skip = [
-    # newer version used by clap_derive
-    # older version used by strum_macros
-    { name = "heck", version = "0.4.1" },
-    # older version used by toml_edit
-    # newer version used by gix-actor
-    { name = "winnow", version = "0.5.40" },
+    # older version used by gix-actor
+    # newer version used by toml_edit
+    { name = "winnow", version = "0.6.26" },
+
+    # older version from getrandom v0.2.15
+    # newer version from getrandom v0.3.1
+    { name = "wasi", version = "0.11.0+wasi-snapshot-preview1" },
+
+    # older version from rustsec v0.30.1
+    # newer version from gix v0.70.0
+    { name = "thiserror", version = "1.0.69" },
+    { name = "thiserror-impl", version = "1.0.69" },
+
+    # older version from gix-hashtable
+    # newer version from indexmap
+    { name = "hashbrown", version = "0.14.5" },
+
+    # older version from ring
+    # newer version from tempfile
+    { name = "getrandom", version = "0.2.15" },
 ]
 
 skip-tree = [
@@ -48,6 +74,8 @@ skip-tree = [
     { name = "windows-sys" },
     # redox_syscall is also not a direct dependency.
     { name = "redox_syscall" },
+    # core-foundation is not a direct dependency.
+    { name = "core-foundation" },
 ]
 
 [sources]

--- a/hashes/cargo-deny
+++ b/hashes/cargo-deny
@@ -1,2 +1,2 @@
-# https://github.com/EmbarkStudios/cargo-deny/archive/0.16.1/cargo-deny-0.16.1.tar.gz
-SHA512 (cargo-deny-0.16.1.tar.gz) = 3801dda508b64cb94ea2b265f52220760f66075396ae3771bcb09e24389d595c2bd29a1f3d3a833e117b663526859e99c14763eb4b8ca75490b6470b5fb3b193
+# https://github.com/EmbarkStudios/cargo-deny/archive/0.18.1/cargo-deny-0.18.1.tar.gz
+SHA512 (cargo-deny-0.18.1.tar.gz) = 003d70fdd171ce756d89665e05c68ff64580a5868ea3153442b2076f65a8f02c49f208394aad4bb648e8f1afca0e5f1ae5701dd170f4bcfda090c9ab50a61375


### PR DESCRIPTION
**Issue number:**
Fixes: #254 


**Description of changes:**
Update `cargo-deny`.


**Testing done:**
License check passes in downstream repos.


**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
