### PR TITLE
macros: fix linker flags for Rust

### DIFF
--- a/macros/rust
+++ b/macros/rust
@@ -11,6 +11,7 @@
 # Enable some optimization, debuginfo, and link hardening.
 %__global_rustflags_base %{shrink: \
   -Copt-level=3 -Cdebuginfo=2 -Cforce-frame-pointers=yes \
+  -Clink-arg=-Wl,-z,relro,-z,now \
   -Clink-arg=-Wl,-z,pack-relative-relocs \
   %{nil}}
 


### PR DESCRIPTION
**Issue number:**
N/A


**Description of changes:**
Bring back `-Wl,-z,relro,-z,now` which was mistakenly dropped during the refactor that added `-Wl,-z,pack-relative-relocs`.

Fixes: 3c00dab53c ("macros: set linker flag to pack relative relocations")


**Testing done:**
Built the SDK and downstream Rust programs.


**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
