### PR TITLE
buildroot: add patches to binutils for CVE-2025-0840

### DIFF
--- a/patches/buildroot/0006-package-binutils-fix-stack-buffer-overflow-at-objdump.patch
+++ b/patches/buildroot/0006-package-binutils-fix-stack-buffer-overflow-at-objdump.patch
@@ -1,0 +1,74 @@
+From 7fbf8d620537d8afd43cdfd2588f552a6ea284ee Mon Sep 17 00:00:00 2001
+From: Piyush Jena <piyushjena1996@gmail.com>
+Date: Mon, 14 Apr 2025 19:52:22 +0000
+Subject: [PATCH] package/binutils: fix stack buffer overflow at objdump
+
+Signed-off-by: Piyush Jena <piyushjena1996@gmail.com>
+---
+ ...verflow-at-objdump-disassemble_bytes.patch | 54 +++++++++++++++++++
+ 1 file changed, 54 insertions(+)
+ create mode 100644 package/binutils/2.43.1/9002-stack-buffer-overflow-at-objdump-disassemble_bytes.patch
+
+diff --git a/package/binutils/2.43.1/9002-stack-buffer-overflow-at-objdump-disassemble_bytes.patch b/package/binutils/2.43.1/9002-stack-buffer-overflow-at-objdump-disassemble_bytes.patch
+new file mode 100644
+index 0000000000..7d24dfecc6
+--- /dev/null
++++ b/package/binutils/2.43.1/9002-stack-buffer-overflow-at-objdump-disassemble_bytes.patch
+@@ -0,0 +1,54 @@
++From baac6c221e9d69335bf41366a1c7d87d8ab2f893 Mon Sep 17 00:00:00 2001
++From: Alan Modra <amodra@gmail.com>
++Date: Wed, 15 Jan 2025 19:13:43 +1030
++Subject: [PATCH] PR32560 stack-buffer-overflow at objdump disassemble_bytes
++
++There's always someone pushing the boundaries.
++
++	PR 32560
++	* objdump.c (MAX_INSN_WIDTH): Define.
++	(insn_width): Make it an unsigned long.
++	(disassemble_bytes): Use MAX_INSN_WIDTH to size buffer.
++	(main <OPTION_INSN_WIDTH>): Restrict size of insn_width.
++---
++ binutils/objdump.c | 10 ++++++----
++ 1 file changed, 6 insertions(+), 4 deletions(-)
++
++diff --git a/binutils/objdump.c b/binutils/objdump.c
++index ecbe39e942e..80044dea580 100644
++--- a/binutils/objdump.c
+++++ b/binutils/objdump.c
++@@ -117,7 +117,8 @@ static bool disassemble_all;		/* -D */
++ static int disassemble_zeroes;		/* --disassemble-zeroes */
++ static bool formats_info;		/* -i */
++ int wide_output;			/* -w */
++-static int insn_width;			/* --insn-width */
+++#define MAX_INSN_WIDTH 49
+++static unsigned long insn_width;	/* --insn-width */
++ static bfd_vma start_address = (bfd_vma) -1; /* --start-address */
++ static bfd_vma stop_address = (bfd_vma) -1;  /* --stop-address */
++ static int dump_debugging;		/* --debugging */
++@@ -3391,7 +3392,7 @@ disassemble_bytes (struct disassemble_info *inf,
++ 	}
++       else
++ 	{
++-	  char buf[50];
+++	  char buf[MAX_INSN_WIDTH + 1];
++ 	  unsigned int bpc = 0;
++ 	  unsigned int pb = 0;
++
++@@ -6070,8 +6071,9 @@ main (int argc, char **argv)
++ 	  break;
++ 	case OPTION_INSN_WIDTH:
++ 	  insn_width = strtoul (optarg, NULL, 0);
++-	  if (insn_width <= 0)
++-	    fatal (_("error: instruction width must be positive"));
+++	  if (insn_width - 1 >= MAX_INSN_WIDTH)
+++	    fatal (_("error: instruction width must be in the range 1 to "
+++		     XSTRING (MAX_INSN_WIDTH)));
++ 	  break;
++ 	case OPTION_INLINES:
++ 	  unwind_inlines = true;
++--
++2.43.5
++
+--
+2.47.1
+


### PR DESCRIPTION
<!--
Tips:
- Please read the CONTRIBUTING document to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->

**Issue number:**
Fixes: [CVE-2025-0840](https://github.com/advisories/GHSA-c5qp-mx9f-m5c7)


**Description of changes:**
- Add the patch that fixes the CVE as mentioned in [NVD](https://nvd.nist.gov/vuln/detail/CVE-2025-0840)


**Testing done:**
- Built an [x86_64, k8s-1.32-nvidia] ami with core-kit and kernel-kit using a custom sdk that includes this patch.
- Verified that instance boots with the above ami.



**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
