### PR TITLE
serialize aws-lc builds inside a Go version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -555,6 +555,7 @@ RUN ./build-aws-lc.sh --arch="${ARCH}" --target="${TARGET}" --go-dir="${HOME}/sd
 # =^..^=   =^..^=   =^..^=   =^..^=   =^..^=   =^..^=   =^..^=   =^..^=   =^..^=
 
 FROM sdk-go-1.23-prep AS sdk-go-1.23-aws-lc-gnu-aarch64
+COPY --chown=0:0 --from=sdk-go-1.23-aws-lc-gnu-x86_64 /etc/group /etc/group
 ENV ARCH="aarch64"
 ENV LIBC="gnu"
 ENV TARGET="${ARCH}-bottlerocket-linux-${LIBC}"
@@ -563,6 +564,7 @@ RUN ./build-aws-lc.sh --arch="${ARCH}" --target="${TARGET}" --go-dir="${HOME}/sd
 # =^..^=   =^..^=   =^..^=   =^..^=   =^..^=   =^..^=   =^..^=   =^..^=   =^..^=
 
 FROM sdk-go-1.23-prep AS sdk-go-1.23-aws-lc-musl-x86_64
+COPY --chown=0:0 --from=sdk-go-1.23-aws-lc-gnu-aarch64 /etc/group /etc/group
 ENV ARCH="x86_64"
 ENV LIBC="musl"
 ENV TARGET="${ARCH}-bottlerocket-linux-${LIBC}"
@@ -571,6 +573,7 @@ RUN ./build-aws-lc.sh --arch="${ARCH}" --target="${TARGET}" --go-dir="${HOME}/sd
 # =^..^=   =^..^=   =^..^=   =^..^=   =^..^=   =^..^=   =^..^=   =^..^=   =^..^=
 
 FROM sdk-go-1.23-prep AS sdk-go-1.23-aws-lc-musl-aarch64
+COPY --chown=0:0 --from=sdk-go-1.23-aws-lc-musl-x86_64 /etc/group /etc/group
 ENV ARCH="aarch64"
 ENV LIBC="musl"
 ENV TARGET="${ARCH}-bottlerocket-linux-${LIBC}"
@@ -587,6 +590,7 @@ RUN ./build-aws-lc.sh --arch="${ARCH}" --target="${TARGET}" --go-dir="${HOME}/sd
 # =^..^=   =^..^=   =^..^=   =^..^=   =^..^=   =^..^=   =^..^=   =^..^=   =^..^=
 
 FROM sdk-go-1.24-prep AS sdk-go-1.24-aws-lc-gnu-aarch64
+COPY --chown=0:0 --from=sdk-go-1.24-aws-lc-gnu-x86_64 /etc/group /etc/group
 ENV ARCH="aarch64"
 ENV LIBC="gnu"
 ENV TARGET="${ARCH}-bottlerocket-linux-${LIBC}"
@@ -595,6 +599,7 @@ RUN ./build-aws-lc.sh --arch="${ARCH}" --target="${TARGET}" --go-dir="${HOME}/sd
 # =^..^=   =^..^=   =^..^=   =^..^=   =^..^=   =^..^=   =^..^=   =^..^=   =^..^=
 
 FROM sdk-go-1.24-prep AS sdk-go-1.24-aws-lc-musl-x86_64
+COPY --chown=0:0 --from=sdk-go-1.24-aws-lc-gnu-aarch64 /etc/group /etc/group
 ENV ARCH="x86_64"
 ENV LIBC="musl"
 ENV TARGET="${ARCH}-bottlerocket-linux-${LIBC}"
@@ -603,6 +608,7 @@ RUN ./build-aws-lc.sh --arch="${ARCH}" --target="${TARGET}" --go-dir="${HOME}/sd
 # =^..^=   =^..^=   =^..^=   =^..^=   =^..^=   =^..^=   =^..^=   =^..^=   =^..^=
 
 FROM sdk-go-1.24-prep AS sdk-go-1.24-aws-lc-musl-aarch64
+COPY --chown=0:0 --from=sdk-go-1.24-aws-lc-musl-x86_64 /etc/group /etc/group
 ENV ARCH="aarch64"
 ENV LIBC="musl"
 ENV TARGET="${ARCH}-bottlerocket-linux-${LIBC}"


### PR DESCRIPTION
**Issue number:**
Related: #266


**Description of changes:**
The delocate phase of the aws-lc build can use up to 25 GiB of RAM, and running eight of them in parallel can lead to OOM even for build hosts with lots of memory.

Force each stage within a Go version to depend on the stage for the previous build, so that at most two versions will build concurrently.


**Testing done:**
Built locally.


**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
