### PR TITLE
govc: update from 0.30.2 v0.46.3

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -783,16 +783,16 @@ RUN \
 
 # =^..^=   =^..^=   =^..^=   =^..^=   =^..^=   =^..^=   =^..^=   =^..^=   =^..^=
 
-FROM sdk-go-1.23 AS sdk-govc
+FROM sdk-go-1.24 AS sdk-govc
 
 USER root
 RUN \
   mkdir -p /usr/libexec/tools /usr/share/licenses/govmomi && \
   chown -R builder:builder /usr/libexec/tools /usr/share/licenses/govmomi
 
-ENV GOVMOMIVER="0.30.2"
-ENV GOVMOMISHORTCOMMIT="9078b0b"
-ENV GOVMOMIDATE="2023-02-01T04:38:23Z"
+ENV GOVMOMIVER="0.46.3"
+ENV GOVMOMISHORTCOMMIT="e5dcb5f"
+ENV GOVMOMIDATE="2024-12-12T20:11:39Z"
 
 USER builder
 WORKDIR /home/builder/go/src/github.com/vmware/govmomi

--- a/hashes/govmomi
+++ b/hashes/govmomi
@@ -1,2 +1,2 @@
-# https://github.com/vmware/govmomi/archive/v0.30.2.tar.gz#/govmomi-0.30.2.tar.gz
-SHA512 (govmomi-0.30.2.tar.gz) = 19128ee73138ee8528678e577a6c03296a8782eaf5828cc1674bd42f793f0adb0121a1a38e039eeb130f89264d4ee31229cb61c5d6210199f92ad95b6f1e4661
+# https://github.com/vmware/govmomi/archive/v0.46.3/govmomi-0.46.3.tar.gz
+SHA512 (govmomi-0.46.3.tar.gz) = 149830359e966a3090348fe80fecc58dfd19394dc5df0cc97e4ee245866738802437c6a099b95e9ff1595696644e6dacba07151ce17b73bd384f3cd918549410


### PR DESCRIPTION
**Description of changes:**

Updates to a newer version of `govc`.

**Testing done:**

Built and launched both archs -- testing the `govc` binaries with `govc version -l`.

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
