### PR TITLE
go1.23: add a patch to fix potential use after free

### DIFF
--- a/patches/go-1.23/0004-crypto-internal-boring-keep-ECDH-public-key-alive-du.patch
+++ b/patches/go-1.23/0004-crypto-internal-boring-keep-ECDH-public-key-alive-du.patch
@@ -1,0 +1,41 @@
+From 472239107b503d2f84fa5a239cc4bdaddb6d9939 Mon Sep 17 00:00:00 2001
+From: Roland Shoemaker <roland@golang.org>
+Date: Fri, 24 Jan 2025 12:21:36 -0800
+Subject: [PATCH] crypto/internal/boring: keep ECDH public key alive during cgo
+ calls
+
+This prevents a possible use-after-free.
+
+Change-Id: I02488206660d38cac5ebf2f11009907ae8f22157
+Reviewed-on: https://go-review.googlesource.com/c/go/+/644119
+LUCI-TryBot-Result: Go LUCI <golang-scoped@luci-project-accounts.iam.gserviceaccount.com>
+Reviewed-by: Filippo Valsorda <filippo@golang.org>
+Reviewed-by: David Chase <drchase@google.com>
+(cherry picked from commit e2e700f8b174f34b44c32d7e923ffe4e7219e171)
+---
+ src/crypto/internal/boring/ecdh.go | 9 +++++++++
+ 1 file changed, 9 insertions(+)
+
+diff --git a/src/crypto/internal/boring/ecdh.go b/src/crypto/internal/boring/ecdh.go
+index 6a5d174c16..64f48907b5 100644
+--- a/src/crypto/internal/boring/ecdh.go
++++ b/src/crypto/internal/boring/ecdh.go
+@@ -134,6 +134,15 @@ func pointBytesECDH(curve string, group *C.GO_EC_GROUP, pt *C.GO_EC_POINT) ([]by
+ }
+ 
+ func ECDH(priv *PrivateKeyECDH, pub *PublicKeyECDH) ([]byte, error) {
++	// Make sure priv and pub are not garbage collected while we are in a cgo
++	// call.
++	//
++	// The call to xCoordBytesECDH should prevent priv from being collected, but
++	// include this in case the code is reordered and there is a subsequent call
++	// cgo call after that point.
++	defer runtime.KeepAlive(priv)
++	defer runtime.KeepAlive(pub)
++
+ 	group := C._goboringcrypto_EC_KEY_get0_group(priv.key)
+ 	if group == nil {
+ 		return nil, fail("EC_KEY_get0_group")
+-- 
+2.47.0
+


### PR DESCRIPTION
**Issue number:**
fixes: #278 

**Description of changes:**
The [Go crypto audit](https://go.dev/blog/tob-crypto-audit) identified a low-level security issue in the crypto implementation. The [fix](github.com/golang/go/commit/e2e700f8b174f34b44c32d7e923ffe4e7219e171) was merged into Go 1.24 and later versions. But Go 1.23  didn't include this patch yet. Therefore, consume the upstream patch to patch Go 1.23

**Testing done:**
- Build a x86_64 ami and it boots successfully
```
[root@admin]# apiclient get os
{
  "os": {
    "arch": "x86_64",
    "build_id": "807acc8b-dirty",
    "pretty_name": "Bottlerocket OS 1.40.0 (aws-k8s-1.32-fips)",
    "variant_id": "aws-k8s-1.32-fips",
    "version_id": "1.40.0"
  }
}
[root@admin]#
```

- Build a aarch64 ami and it boots successfully
```
[root@admin]# apiclient get os
{
  "os": {
    "arch": "aarch64",
    "build_id": "807acc8b-dirty",
    "pretty_name": "Bottlerocket OS 1.40.0 (aws-k8s-1.32-fips)",
    "variant_id": "aws-k8s-1.32-fips",
    "version_id": "1.40.0"
  }
}
```

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
