### PR TITLE
Go updates

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -496,7 +496,7 @@ USER root
 RUN dnf -y install golang
 
 ENV GO125VER="1.25.3"
-ENV GO124VER="1.24.8"
+ENV GO124VER="1.24.9"
 
 # =^..^=   =^..^=   =^..^=   =^..^=   =^..^=   =^..^=   =^..^=   =^..^=   =^..^=
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -495,7 +495,7 @@ ENV AWS_LC_FIPS_VER="3.0.0"
 USER root
 RUN dnf -y install golang
 
-ENV GO125VER="1.25.2"
+ENV GO125VER="1.25.3"
 ENV GO124VER="1.24.8"
 
 # =^..^=   =^..^=   =^..^=   =^..^=   =^..^=   =^..^=   =^..^=   =^..^=   =^..^=

--- a/hashes/go-1.24
+++ b/hashes/go-1.24
@@ -1,2 +1,2 @@
-# https://go.dev/dl/go1.24.8.src.tar.gz
-SHA512 (go1.24.8.src.tar.gz) = 3233c75223b310d14ccb1846e192d0d4867e8ecc1091c9853bc536f5051cdfb8682ae2f86b5caec77b1f3cbfaf5864c9231fb3a756471ff77d7a904e79bb3f15
+# https://go.dev/dl/go1.24.9.src.tar.gz
+SHA512 (go1.24.9.src.tar.gz) = f553a6bdafa9e59d33756c99f6180dcb7e51762733f300488cdab1d42b918e0fff87fa42d714a6b667e039dd22e1ea14ef5f6e3eb1c9c215ff620d559a5c091a

--- a/hashes/go-1.25
+++ b/hashes/go-1.25
@@ -1,2 +1,2 @@
-# https://go.dev/dl/go1.25.2.src.tar.gz
-SHA512 (go1.25.2.src.tar.gz) = 2700ceca314bb78b8ff97aa8703442b60eceb3acbad46b7959739bb0399174f27af372c7f72cd1adb83997adacbf43e2e2572e85fa5cf2a18271d0ef1ee0b8b4
+# https://go.dev/dl/go1.25.3.src.tar.gz
+SHA512 (go1.25.3.src.tar.gz) = 91d32bbff864c06b5ee7b914d3d95c59462352a4c395adba85eaab72704a8aa4d19ac2a361ed64774dce3c8e01a8d4feadf1a788814f6d7b4072a3bdfefbb3b4


### PR DESCRIPTION
**Description of changes:**
- Go - 1.24 updated to v1.24.9
- Go - 1.25 updated to v1.25.3

**Testing done:**
core-kit and ami builds - verify Go version
```
[root@admin]# go version ./.bottlerocket/rootfs/x86_64-bottlerocket-linux-gnu/sys-root/usr/bin/aws-iam-authenticator
./.bottlerocket/rootfs/x86_64-bottlerocket-linux-gnu/sys-root/usr/bin/aws-iam-authenticator: go1.25.3 X:boringcrypto
[root@admin]# go version ./.bottlerocket/rootfs/x86_64-bottlerocket-linux-gnu/sys-root/usr/bin/host-ctr
./.bottlerocket/rootfs/x86_64-bottlerocket-linux-gnu/sys-root/usr/bin/host-ctr: go1.24.9 X:boringcrypto
```

fips-test - got handshake failure when non-compliant cipher was used and accepted when compliant cipher was used

client side
```
[root@admin]# sheltie ctr images pull ec2-*****.us-west-2.compute.amazonaws.com:8043/test:latest
INFO[0000] trying next host                              error="failed to do request: Head \"https://ec2-54-149-221-64.us-west-2.compute.amazonaws.com:8043/v2/test/manifests/latest\": remote error: tls: handshake failure" host="ec2-*****.us-west-2.compute.amazonaws.com:8043"
ctr: failed to resolve reference "ec2-*****.us-west-2.compute.amazonaws.com:8043/test:latest": failed to do request: Head "https://ec2-*****.us-west-2.compute.amazonaws.com:8043/v2/test/manifests/latest": remote error: tls: handshake failure
[root@admin]# sheltie host-ctr pull-image --source ec2-54-149-221-64.us-west-2.compute.amazonaws.com:8043/test:test
time="2025-10-14T10:05:22Z" level=info msg="Image does not exist, proceeding to pull image from source." ref="ec2-*****.us-west-2.compute.amazonaws.com:8043/test:test"
time="2025-10-14T10:05:22Z" level=info msg="trying next host" error="failed to do request: Head \"https://ec2-*****.us-west-2.compute.amazonaws.com:8043/v2/test/manifests/test\": remote error: tls: handshake failure" host="ec2-54-149-221-64.us-west-2.compute.amazonaws.com:8043"
time="2025-10-14T10:05:22Z" level=warning msg="failed to pull image. waiting 4.56s before retrying..." error="failed to resolve reference \"ec2-*****.us-west-2.compute.amazonaws.com:8043/test:test\": failed to do request: Head \"https://ec2-54-149-221-64.us-west-2.compute.amazonaws.com:8043/v2/test/manifests/test\": remote error: tls: handshake failure"
^C
[root@admin]# sheltie host-ctr pull-image --source ec2-*****.us-west-2.compute.amazonaws.com:8043/test:test
time="2025-10-14T10:05:54Z" level=info msg="Image does not exist, proceeding to pull image from source." ref="ec2-*****.us-west-2.compute.amazonaws.com:8043/test:test"
^C
[root@admin]# sheltie ctr images pull ec2-*****.us-west-2.compute.amazonaws.com:8043/test:latest
ec2-54-149-221-64.us-west-2.compute.amazonaws.com:8043/test:latest: resolving      |--------------------------------------|
elapsed: 9.1 s                                                      total:   0.0 B (0.0 B/s)
^C
```
server side
```
[root@nginx-mmbs7 ssl]# openssl s_server -accept 443 -cert server.crt -key server.key -cipher 'ECDHE-RSA-CHACHA20-POLY1305' -ciphersuites 'TLS_CHACHA20_POLY1305_SHA256'
Using default temp DH parameters
ACCEPT
ERROR
40E798575D7F0000:error:0A0000C1:SSL routines:tls_early_post_process_client_hello:no shared cipher:ssl/statem/statem_srvr.c:1842:
shutting down SSL
CONNECTION CLOSED
ERROR
40E798575D7F0000:error:0A0000C1:SSL routines:tls_early_post_process_client_hello:no shared cipher:ssl/statem/statem_srvr.c:1842:
shutting down SSL
CONNECTION CLOSED
^C
[root@nginx-mmbs7 ssl]# openssl s_server -accept 443 -cert server.crt -key server.key -cipher 'ECDHE-RSA-AES128-GCM-SHA256' -ciphersuites 'TLS_AES_128_GCM_SHA256'
Using default temp DH parameters
ACCEPT
-----BEGIN SSL SESSION PARAMETERS-----
*****
-----END SSL SESSION PARAMETERS-----
Shared ciphers:ECDHE-RSA-AES128-GCM-SHA256:TLS_AES_128_GCM_SHA256
Signature Algorithms: RSA-PSS+SHA256:RSA-PSS+SHA384:RSA-PSS+SHA512:RSA+SHA256:ECDSA+SHA256:RSA+SHA384:ECDSA+SHA384:RSA+SHA512:ECDSA+SHA512
Shared Signature Algorithms: RSA-PSS+SHA256:RSA-PSS+SHA384:RSA-PSS+SHA512:RSA+SHA256:ECDSA+SHA256:RSA+SHA384:ECDSA+SHA384:RSA+SHA512:ECDSA+SHA512
Supported groups: secp256r1:secp384r1:secp521r1
Shared groups: secp256r1:secp384r1:secp521r1
CIPHER is TLS_AES_128_GCM_SHA256
This TLS version forbids renegotiation.
HEAD /v2/test/manifests/test HTTP/1.1
Host: ec2-54-149-221-64.us-west-2.compute.amazonaws.com:8043
User-Agent: containerd/1.7.28+unknown
Accept: application/vnd.docker.distribution.manifest.v2+json, application/vnd.docker.distribution.manifest.list.v2+json, application/vnd.oci.image.manifest.v1+json, application/vnd.oci.image.index.v1+json, */*

ERROR
40D730BC1E7F0000:error:0A000126:SSL routines::unexpected eof while reading:ssl/record/rec_layer_s3.c:689:
shutting down SSL
CONNECTION CLOSED
-----BEGIN SSL SESSION PARAMETERS-----
*****
-----END SSL SESSION PARAMETERS-----
Shared ciphers:ECDHE-RSA-AES128-GCM-SHA256:TLS_AES_128_GCM_SHA256
Signature Algorithms: RSA-PSS+SHA256:RSA-PSS+SHA384:RSA-PSS+SHA512:RSA+SHA256:ECDSA+SHA256:RSA+SHA384:ECDSA+SHA384:RSA+SHA512:ECDSA+SHA512
Shared Signature Algorithms: RSA-PSS+SHA256:RSA-PSS+SHA384:RSA-PSS+SHA512:RSA+SHA256:ECDSA+SHA256:RSA+SHA384:ECDSA+SHA384:RSA+SHA512:ECDSA+SHA512
Supported groups: secp256r1:secp384r1:secp521r1
Shared groups: secp256r1:secp384r1:secp521r1
CIPHER is TLS_AES_128_GCM_SHA256
This TLS version forbids renegotiation.
HEAD /v2/test/manifests/latest HTTP/1.1
Host: ec2-54-149-221-64.us-west-2.compute.amazonaws.com:8043
User-Agent: containerd/1.7.28+bottlerocket
Accept: application/vnd.docker.distribution.manifest.v2+json, application/vnd.docker.distribution.manifest.list.v2+json, application/vnd.oci.image.manifest.v1+json, application/vnd.oci.image.index.v1+json, */*

ERROR
40D730BC1E7F0000:error:0A000126:SSL routines::unexpected eof while reading:ssl/record/rec_layer_s3.c:689:
shutting down SSL
CONNECTION CLOSED
^[[A^C
```

Quick test with k8s-1.32 - passed
```
 NAME                                 TYPE       STATE            PASSED       FAILED       SKIPPED   BUILD ID             LAST UPDATE              
 x86-64-aws-k8s-132-fips-quick        Test       passed                5            0          6623   a2524ed7-dirty       2025-10-14T10:55:21Z     
[cargo-make][1] INFO - Build Done in 1.32 seconds.
[cargo-make] INFO - Build Done in 2.23 seconds.
```


**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
