### PR TITLE
add dependencies for libbpf and systemd-boot

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -989,6 +989,7 @@ RUN \
     groff \
     kpartx \
     less \
+    libbpf-devel \
     libcap-devel \
     libkcapi-hmaccalc \
     lz4 \

--- a/Dockerfile
+++ b/Dockerfile
@@ -280,8 +280,8 @@ FROM sdk-libc AS sdk-rust
 
 USER root
 RUN \
-  mkdir -p /usr/libexec/rust && \
-  chown -R builder:builder /usr/libexec/rust
+  mkdir -p /usr/libexec/{rust,llvm} && \
+  chown -R builder:builder /usr/libexec/{rust,llvm}
 
 ARG HOST_ARCH
 ENV VENDOR="bottlerocket"
@@ -332,7 +332,10 @@ COPY ./configs/rust/targets ./targets
 COPY ./configs/rust/config.toml.in ./
 RUN \
   sed -e "s,@HOST_TRIPLE@,${HOST_ARCH}-unknown-linux-gnu,g" config.toml.in > config.toml && \
-  RUSTUP_DIST_SERVER=example:// RUST_TARGET_PATH=${PWD}/targets python3 ./x.py install && \
+  RUSTUP_DIST_SERVER=example:// RUST_TARGET_PATH=${PWD}/targets python3 ./x.py install
+
+# Copy target configs into the installed Rust environment.
+RUN \
   for arch in x86_64 aarch64 ; do \
     for libc in gnu musl ; do \
       cp \
@@ -341,11 +344,31 @@ RUN \
     done ; \
   done
 
+# Copy out the LLVM toolchain that was built along with Rust.
+RUN \
+  rm -rf "build/${HOST_ARCH}-unknown-linux-gnu/llvm/build" && \
+  rsync -aq "build/${HOST_ARCH}-unknown-linux-gnu/llvm/" /usr/libexec/llvm/
+
 RUN \
   install -p -m 0644 -Dt licenses COPYRIGHT LICENSE-*
 
 # Set appropriate environment for using this Rust compiler to build tools
 ENV PATH="/usr/libexec/rust/bin:$PATH" LD_LIBRARY_PATH="/usr/libexec/rust/lib"
+
+# =^..^=   =^..^=   =^..^=   =^..^=   =^..^=   =^..^=   =^..^=   =^..^=   =^..^=
+
+FROM scratch AS sdk-llvm
+
+# Copy the LLVM install directly to `/usr`, so clang can auto-discover the
+# GCC target toolchains.
+COPY --from=sdk-rust /usr/libexec/llvm/ /usr/
+
+# =^..^=   =^..^=   =^..^=   =^..^=   =^..^=   =^..^=   =^..^=   =^..^=   =^..^=
+
+# Merge the LLVM install with the rest of our toolchains and C libraries for
+# later use by the AWS-LC builds.
+FROM sdk-libc AS sdk-libc-llvm
+COPY --from=sdk-llvm / /
 
 # =^..^=   =^..^=   =^..^=   =^..^=   =^..^=   =^..^=   =^..^=   =^..^=   =^..^=
 
@@ -474,7 +497,7 @@ RUN \
 
 # =^..^=   =^..^=   =^..^=   =^..^=   =^..^=   =^..^=   =^..^=   =^..^=   =^..^=
 
-FROM sdk-libc AS sdk-go-prep
+FROM sdk-libc-llvm AS sdk-go-prep
 
 # Set up the environment for building.
 ENV GOOS="linux"
@@ -953,7 +976,6 @@ USER root
 RUN \
   dnf -y install --setopt=install_weak_deps=False \
     ccache \
-    clang \
     createrepo_c \
     dosfstools \
     e2fsprogs \
@@ -1117,11 +1139,14 @@ COPY --from=sdk-libc-musl / /
 # "sdk-libc-gnu" has the GNU C library and headers.
 COPY --from=sdk-libc-gnu / /
 
-# "sdk-rust" has our Rust toolchain with the required targets.
+# "sdk-rust" has our Rust toolchains with the required targets.
 COPY --chown=0:0 --from=sdk-rust /usr/libexec/rust/ /usr/libexec/rust/
 COPY --chown=0:0 --from=sdk-rust \
   /home/builder/rust/licenses/ \
   /usr/share/licenses/rust/
+
+# "sdk-llvm" has our LLVM toolchain.
+COPY --chown=0:0 --from=sdk-llvm / /
 
 # "sdk-go" has the Go toolchain and standard library builds.
 COPY --chown=0:0 --from=sdk-go-1.25 /home/builder/sdk-go/bin /usr/libexec/go-1.25/bin/

--- a/Dockerfile
+++ b/Dockerfile
@@ -1000,6 +1000,7 @@ RUN \
     protobuf-compiler \
     protobuf-devel \
     python3-devel \
+    python3-pyelftools \
     python3-jinja2 \
     python3-virt-firmware \
     qemu-img \

--- a/configs/rust/config.toml.in
+++ b/configs/rust/config.toml.in
@@ -26,7 +26,11 @@ debuginfo-level-std = 2
 rpath = false
 
 [llvm]
+download-ci-llvm = false
 static-libstdcpp = false
+targets = "AArch64;BPF;X86"
+clang = true
+link-shared = true
 
 [install]
 prefix = "/usr/libexec/rust"


### PR DESCRIPTION
**Issue number:**
N/A


**Description of changes:**
Add libbpf-devel to support downstream builds that use libbpf-rs.

Vendor clang and LLVM from the Rust build, to tighten control over the tool chain used to compile BPF programs.

Include pyelftools to enable building systemd-boot on aarch64.


**Testing done:**
Built a Rust program that used libbpf-rs to load a BPF LSM hook.

Built systemd-boot for arm64 on arm64. There are other problems with building for x86_64, but this is a start to unblock experiments.


**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
