### PR TITLE
Go updates

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -519,7 +519,7 @@ USER root
 RUN dnf -y install golang
 
 ENV GO125VER="1.25.3"
-ENV GO124VER="1.24.9"
+ENV GO124VER="1.24.11"
 
 # =^..^=   =^..^=   =^..^=   =^..^=   =^..^=   =^..^=   =^..^=   =^..^=   =^..^=
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -518,7 +518,7 @@ ENV AWS_LC_FIPS_VER="3.0.0"
 USER root
 RUN dnf -y install golang
 
-ENV GO125VER="1.25.3"
+ENV GO125VER="1.25.5"
 ENV GO124VER="1.24.11"
 
 # =^..^=   =^..^=   =^..^=   =^..^=   =^..^=   =^..^=   =^..^=   =^..^=   =^..^=

--- a/hashes/go-1.24
+++ b/hashes/go-1.24
@@ -1,2 +1,2 @@
-# https://go.dev/dl/go1.24.9.src.tar.gz
-SHA512 (go1.24.9.src.tar.gz) = f553a6bdafa9e59d33756c99f6180dcb7e51762733f300488cdab1d42b918e0fff87fa42d714a6b667e039dd22e1ea14ef5f6e3eb1c9c215ff620d559a5c091a
+# https://go.dev/dl/go1.24.11.src.tar.gz
+SHA512 (go1.24.11.src.tar.gz) = 9344039d231e50b63f52acbdd6cf2f483a4052d95b5fcc3e8a6d8fde80f0195f66ac5588302809ff0425de4d7c6b428ae842ec33b468c7020873acedbdea16ef

--- a/hashes/go-1.25
+++ b/hashes/go-1.25
@@ -1,2 +1,2 @@
-# https://go.dev/dl/go1.25.3.src.tar.gz
-SHA512 (go1.25.3.src.tar.gz) = 91d32bbff864c06b5ee7b914d3d95c59462352a4c395adba85eaab72704a8aa4d19ac2a361ed64774dce3c8e01a8d4feadf1a788814f6d7b4072a3bdfefbb3b4
+# https://go.dev/dl/go1.25.5.src.tar.gz
+SHA512 (go1.25.5.src.tar.gz) = 97ec368521253bce610e1e3a6f10460f4a38eba440289553a40ab27afcdf2bb9b426d150ffaa3be8db50e84a00a4eb723a631ebc4f39168bc133bf7b2f1ccf66


### PR DESCRIPTION
<!--
Tips:
- Please read the CONTRIBUTING document to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->

**Description of changes:**
- Update go sources to the latest versions


**Testing done:**
- core-kit and ami builds - verify Go version
```bash
[root@admin]# go version ./.bottlerocket/rootfs/x86_64-bottlerocket-linux-gnu/sys-root/usr/bin/aws-iam-authenticator
./.bottlerocket/rootfs/x86_64-bottlerocket-linux-gnu/sys-root/usr/bin/aws-iam-authenticator: go1.25.5
[root@admin]# go version ./.bottlerocket/rootfs/x86_64-bottlerocket-linux-gnu/sys-root/usr/bin/host-ctr
./.bottlerocket/rootfs/x86_64-bottlerocket-linux-gnu/sys-root/usr/bin/host-ctr: go1.24.11
```
- fips test
client side failure with non compliant cipher
```
bash-5.1# host-ctr pull-image --source ec2-44-247-125-82.us-west-2.compute.amazonaws.com:8043/test:test
time="2025-12-05T00:41:56Z" level=info msg="Image does not exist, proceeding to pull image from source." ref="ec2-44-247-125-82.us-west-2.compute.amazonaws.com:8043/test:test"
time="2025-12-05T00:41:56Z" level=info msg="trying next host" error="failed to do request: Head \"https://ec2-44-247-125-82.us-west-2.compute.amazonaws.com:8043/v2/test/manifests/test\": remote error: tls: handshake failure" host="ec2-44-247-125-82.us-west-2.compute.amazonaws.com:8043"
time="2025-12-05T00:41:56Z" level=warning msg="failed to pull image. waiting 5.378s before retrying..." error="failed to resolve reference \"ec2-44-247-125-82.us-west-2.compute.amazonaws.com:8043/test:test\": failed to do request: Head \"https://ec2-44-247-125-82.us-west-2.compute.amazonaws.com:8043/v2/test/manifests/test\": remote error: tls: handshake failure"
time="2025-12-05T00:42:02Z" level=info msg="trying next host" error="failed to do request: Head \"https://ec2-44-247-125-82.us-west-2.compute.amazonaws.com:8043/v2/test/manifests/test\": remote error: tls: handshake failure" host="ec2-44-247-125-82.us-west-2.compute.amazonaws.com:8043"
time="2025-12-05T00:42:02Z" level=warning msg="failed to pull image. waiting 7.634s before retrying..." error="failed to resolve reference \"ec2-44-247-125-82.us-west-2.compute.amazonaws.com:8043/test:test\": failed to do request: Head \"https://ec2-44-247-125-82.us-west-2.compute.amazonaws.com:8043/v2/test/manifests/test\": remote error: tls: handshake failure"
bash-5.1# apiclient get os
{
  "os": {
    "arch": "x86_64",
    "build_id": "47438798-dirty",
    "pretty_name": "Bottlerocket OS 1.51.0 (aws-k8s-1.34-fips)",
    "variant_id": "aws-k8s-1.34-fips",
    "version_id": "1.51.0"
  }
}
```
server side fails with non compliant cipher
```
[root@nginx-jj98b ssl]# openssl s_server -accept 443 -cert server.crt -key server.key -cipher 'ECDHE-RSA-CHACHA20-POLY1305' -ciphersuites 'TLS_CHACHA20_POLY1305_SHA256'
Using default temp DH parameters
ACCEPT
ERROR
00634E70C37F0000:error:0A0000C1:SSL routines:tls_early_post_process_client_hello:no shared cipher:ssl/statem/statem_srvr.c:1843:
shutting down SSL
CONNECTION CLOSED
ERROR
00634E70C37F0000:error:0A0000C1:SSL routines:tls_early_post_process_client_hello:no shared cipher:ssl/statem/statem_srvr.c:1843:
shutting down SSL
CONNECTION CLOSED
```

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
