### PR TITLE
SBOM merge performance

### DIFF
--- a/sbomtool/README.md
+++ b/sbomtool/README.md
@@ -65,7 +65,7 @@ The merge command combines multiple SBOM files while:
 - Maintaining SBOM format integrity
 - Providing comprehensive merge statistics
 
-All input files must be in the same format (SPDX or CycloneDX).
+Input files can be mixed formats (SPDX and CycloneDX). The output format is determined by the first input file.
 
 ### Examples
 

--- a/sbomtool/cmd/sbomtool/main.go
+++ b/sbomtool/cmd/sbomtool/main.go
@@ -463,6 +463,7 @@ All input files must be the same format (SPDX or CycloneDX).`,
 	}
 
 	mergeCmd.Flags().String("output", "", "Output file path for merged SBOM (required)")
+	mergeCmd.Flags().String("output-format", "", "Output format: spdx, cyclonedx, or both (default: first input's format)")
 	mergeCmd.Flags().Int("level", 0, "Merge level (reserved for future use)")
 	if err := mergeCmd.MarkFlagRequired("output"); err != nil {
 		slog.Error("Failed to mark output flag as required", "error", err)
@@ -485,8 +486,7 @@ func validateMergeFlags(cmd *cobra.Command, args []string) error {
 		}
 	}
 
-	var detectedFormat string
-	for i, inputFile := range args {
+	for _, inputFile := range args {
 		if err := validate.ValidateFilePath(inputFile, "input SBOM", true); err != nil {
 			return &fileSystemError{
 				Operation:  "input SBOM validation",
@@ -504,27 +504,6 @@ func validateMergeFlags(cmd *cobra.Command, args []string) error {
 				Suggestion: "Ensure all input files are valid SPDX 2.3 or CycloneDX 1.6 JSON files.",
 			}
 		}
-
-		format, err := validate.DetectSBOMFormat(inputFile)
-		if err != nil {
-			return &fileSystemError{
-				Operation:  "SBOM format detection",
-				Path:       inputFile,
-				Cause:      err,
-				Suggestion: "Ensure the SBOM file contains valid JSON.",
-			}
-		}
-
-		if i == 0 {
-			detectedFormat = format
-		} else if format != detectedFormat {
-			return &validationError{
-				Field:      "SBOM format consistency",
-				Value:      format,
-				Message:    fmt.Sprintf("all input files must be the same format, expected %s but got %s", detectedFormat, format),
-				Suggestion: "Ensure all input SBOM files use the same format (all SPDX or all CycloneDX).",
-			}
-		}
 	}
 
 	return nil
@@ -534,9 +513,21 @@ func validateMergeFlags(cmd *cobra.Command, args []string) error {
 func runMerge(cmd *cobra.Command, args []string) error {
 	outputPath, _ := cmd.Flags().GetString("output")
 	level, _ := cmd.Flags().GetInt("level")
+	outputFormat, _ := cmd.Flags().GetString("output-format")
+
+	// Map user-friendly format names to Syft format IDs
+	switch outputFormat {
+	case "spdx":
+		outputFormat = "spdx-json"
+	case "cyclonedx":
+		outputFormat = "cyclonedx-json"
+	case "both":
+		outputFormat = "both"
+	}
 
 	config := merge.MergeConfig{
-		Level: level,
+		OutputFormat: outputFormat,
+		Level:        level,
 	}
 
 	slog.Info("Starting SBOM merge process",
@@ -549,12 +540,29 @@ func runMerge(cmd *cobra.Command, args []string) error {
 	}
 
 	// Save the merged SBOM
-	if err := processor.SaveSBOM(result.MergedSBOM, outputPath, result.OutputFormat); err != nil {
-		return &fileSystemError{
-			Operation:  "SBOM saving",
-			Path:       outputPath,
-			Cause:      err,
-			Suggestion: "Ensure you have write permissions to the output location.",
+	// Use user-specified format if provided, otherwise use detected format from input
+	saveFormat := result.OutputFormat
+	if outputFormat != "" && outputFormat != "both" {
+		saveFormat = outputFormat
+	}
+
+	if outputFormat == "both" {
+		if err := processor.SaveSBOMBothFormats(cmd.Context(), result.MergedSBOM, outputPath); err != nil {
+			return &fileSystemError{
+				Operation:  "SBOM saving (both formats)",
+				Path:       outputPath,
+				Cause:      err,
+				Suggestion: "Ensure you have write permissions to the output location.",
+			}
+		}
+	} else {
+		if err := processor.SaveSBOM(result.MergedSBOM, outputPath, saveFormat); err != nil {
+			return &fileSystemError{
+				Operation:  "SBOM saving",
+				Path:       outputPath,
+				Cause:      err,
+				Suggestion: "Ensure you have write permissions to the output location.",
+			}
 		}
 	}
 

--- a/sbomtool/go.mod
+++ b/sbomtool/go.mod
@@ -6,6 +6,7 @@ require (
 	github.com/anchore/syft v1.39.0
 	github.com/spf13/cobra v1.10.2
 	github.com/stretchr/testify v1.11.1
+	golang.org/x/sync v0.18.0
 	modernc.org/sqlite v1.41.0
 )
 

--- a/sbomtool/go.work.sum
+++ b/sbomtool/go.work.sum
@@ -601,6 +601,7 @@ golang.org/x/lint v0.0.0-20210508222113-6edffad5e616 h1:VLliZ0d+/avPrXXH+OakdXhp
 golang.org/x/mobile v0.0.0-20190719004257-d2bd2a29d028 h1:4+4C/Iv2U4fMZBiMCc98MG1In4gJY5YRhtpDNeDeHWs=
 golang.org/x/oauth2 v0.32.0 h1:jsCblLleRMDrxMN29H3z/k1KliIvpLgCkE6R8FXXNgY=
 golang.org/x/oauth2 v0.32.0/go.mod h1:lzm5WQJQwKZ3nwavOZ3IS5Aulzxi68dUSgRHujetwEA=
+golang.org/x/sync v0.18.0/go.mod h1:9KTHXmSnoGruLpwFjVSX0lNNA75CykiMECbovNTZqGI=
 golang.org/x/telemetry v0.0.0-20251008203120-078029d740a8 h1:LvzTn0GQhWuvKH/kVRS3R3bVAsdQWI7hvfLHGgh9+lU=
 golang.org/x/telemetry v0.0.0-20251008203120-078029d740a8/go.mod h1:Pi4ztBfryZoJEkyFTI5/Ocsu2jXyDr6iSdgJiYE/uwE=
 google.golang.org/api v0.62.0 h1:PhGymJMXfGBzc4lBRmrx9+1w4w2wEzURHNGF/sD/xGc=

--- a/sbomtool/internal/buildroot/scanner.go
+++ b/sbomtool/internal/buildroot/scanner.go
@@ -6,29 +6,36 @@ import (
 	"log/slog"
 	"os"
 	"path/filepath"
+	"runtime"
+	"slices"
 	"strings"
+	"sync"
 	"time"
 )
 
 // Scanner provides comprehensive buildroot directory scanning functionality.
-// It implements efficient recursive directory traversal with configurable depth limits,
-// file type detection, and path normalization for integration with Syft's file coordinate system.
 type Scanner struct {
 	maxDepth        int
 	excludePatterns []string
 }
 
 // ScanResult contains the complete results of a buildroot directory scan.
-// It includes categorized file lists, normalized paths for Syft compatibility,
-// and performance metrics from the scanning operation.
+// Note: mu is only initialized by ScanDirectory(); zero-value ScanResults have nil mu.
 type ScanResult struct {
 	AllFiles        []string
 	RegularFiles    []string
 	SymbolicLinks   []string
 	Directories     []string
-	NormalizedPaths map[string]string // buildroot path -> installed path
+	NormalizedPaths map[string]string
 	TotalSize       int64
 	ScanDuration    time.Duration
+	mu              *sync.RWMutex
+}
+
+// fileWork represents a file to be processed by workers.
+type fileWork struct {
+	path  string
+	entry os.DirEntry
 }
 
 // NewScanner creates a new buildroot scanner with the specified configuration.
@@ -40,13 +47,9 @@ func NewScanner(maxDepth int, excludePatterns []string) *Scanner {
 }
 
 // ScanDirectory performs comprehensive recursive scanning of the buildroot directory.
-//
-// It discovers all files, categorizes them by type, and normalizes paths for Syft compatibility.
-// The scan respects depth limits and exclusion patterns to optimize performance.
 func (s *Scanner) ScanDirectory(buildrootPath string) (*ScanResult, error) {
 	startTime := time.Now()
 
-	// Verify buildroot exists and is accessible
 	if _, err := os.Stat(buildrootPath); err != nil {
 		return nil, fmt.Errorf("buildroot path not accessible: %w", err)
 	}
@@ -57,14 +60,53 @@ func (s *Scanner) ScanDirectory(buildrootPath string) (*ScanResult, error) {
 		SymbolicLinks:   make([]string, 0),
 		Directories:     make([]string, 0),
 		NormalizedPaths: make(map[string]string),
+		mu:              &sync.RWMutex{},
 	}
 
-	err := s.scanRecursive(buildrootPath, 0, result)
-	if err != nil {
-		return nil, fmt.Errorf("failed to scan buildroot: %w", err)
+	// Start worker pool for parallel file processing
+	numWorkers := runtime.GOMAXPROCS(0)
+	// Buffer 100 items per worker to reduce contention while limiting memory usage
+	workCh := make(chan fileWork, numWorkers*100)
+	var wg sync.WaitGroup
+	var workerErr error
+	var errMu sync.Mutex
+	for i := 0; i < numWorkers; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for work := range workCh {
+				if err := s.processFile(work.path, work.entry, result); err != nil {
+					errMu.Lock()
+					if workerErr == nil {
+						workerErr = err
+					} else {
+						slog.Debug("Additional worker error", "path", work.path, "error", err)
+					}
+					errMu.Unlock()
+				}
+			}
+		}()
 	}
 
-	// Normalize all paths for Syft compatibility
+	// Walk directories sequentially, send files to workers
+	walkErr := s.walkDirectories(buildrootPath, 0, result, workCh)
+	close(workCh)
+	wg.Wait()
+
+	if walkErr != nil {
+		return nil, fmt.Errorf("failed to scan buildroot: %w", walkErr)
+	}
+	if workerErr != nil {
+		return nil, fmt.Errorf("failed to scan buildroot: %w", workerErr)
+	}
+
+	// Sort for deterministic output (parallel workers append in arbitrary order)
+	slices.Sort(result.AllFiles)
+	slices.Sort(result.RegularFiles)
+	slices.Sort(result.SymbolicLinks)
+	slices.Sort(result.Directories)
+
+	// Build normalized paths (safe after workers complete)
 	for _, filePath := range result.AllFiles {
 		normalized, err := BuildrootToInstalled(filePath, buildrootPath)
 		if err != nil {
@@ -89,17 +131,8 @@ func (s *Scanner) ScanDirectory(buildrootPath string) (*ScanResult, error) {
 	return result, nil
 }
 
-// GetNormalizedPaths extracts normalized paths from scan results for Syft file coordinate matching.
-func (sr *ScanResult) GetNormalizedPaths() []string {
-	var normalizedPaths []string
-	for _, normalized := range sr.NormalizedPaths {
-		normalizedPaths = append(normalizedPaths, normalized)
-	}
-	return normalizedPaths
-}
-
-// scanRecursive performs recursive directory scanning with depth control.
-func (s *Scanner) scanRecursive(currentPath string, depth int, result *ScanResult) error {
+// walkDirectories walks directories sequentially and sends files to workCh.
+func (s *Scanner) walkDirectories(currentPath string, depth int, result *ScanResult, workCh chan<- fileWork) error {
 	if depth > s.maxDepth {
 		return nil
 	}
@@ -120,33 +153,75 @@ func (s *Scanner) scanRecursive(currentPath string, depth int, result *ScanResul
 			continue
 		}
 
-		info, err := entry.Info()
-		if err != nil {
-			return fmt.Errorf("failed to get file info for %s: %w", fullPath, err)
-		}
-
-		result.TotalSize += info.Size()
-		result.AllFiles = append(result.AllFiles, fullPath)
-
-		switch {
-		case info.Mode().IsRegular():
-			result.RegularFiles = append(result.RegularFiles, fullPath)
-
-		case info.Mode()&os.ModeSymlink != 0:
-			result.SymbolicLinks = append(result.SymbolicLinks, fullPath)
-
-		case info.IsDir():
+		if entry.IsDir() {
+			// Process directory info inline (cheap)
+			info, err := entry.Info()
+			if err != nil {
+				return fmt.Errorf("failed to get dir info for %s: %w", fullPath, err)
+			}
+			size := info.Size()
+			result.mu.Lock()
+			result.AllFiles = append(result.AllFiles, fullPath)
 			result.Directories = append(result.Directories, fullPath)
-			if err := s.scanRecursive(fullPath, depth+1, result); err != nil {
+			result.TotalSize += size
+			result.mu.Unlock()
+
+			// Recurse into subdirectory
+			if err := s.walkDirectories(fullPath, depth+1, result, workCh); err != nil {
 				return err
 			}
+		} else {
+			// Send file to worker pool for parallel processing
+			workCh <- fileWork{path: fullPath, entry: entry}
 		}
 	}
 
 	return nil
 }
 
-// shouldExclude checks if a path should be excluded from scanning based on configured patterns.
+// processFile processes a single file (called by workers).
+func (s *Scanner) processFile(fullPath string, entry os.DirEntry, result *ScanResult) error {
+	info, err := os.Lstat(fullPath)
+	if err != nil {
+		return fmt.Errorf("failed to get file info for %s: %w", fullPath, err)
+	}
+
+	if info.Mode()&os.ModeSymlink != 0 {
+		size := info.Size()
+		result.mu.Lock()
+		result.AllFiles = append(result.AllFiles, fullPath)
+		result.SymbolicLinks = append(result.SymbolicLinks, fullPath)
+		result.TotalSize += size
+		result.mu.Unlock()
+		return nil
+	}
+
+	size := info.Size()
+	result.mu.Lock()
+	result.AllFiles = append(result.AllFiles, fullPath)
+	result.TotalSize += size
+	if info.Mode().IsRegular() {
+		result.RegularFiles = append(result.RegularFiles, fullPath)
+	}
+	result.mu.Unlock()
+
+	return nil
+}
+
+// GetNormalizedPaths extracts normalized paths from scan results.
+func (sr *ScanResult) GetNormalizedPaths() []string {
+	if sr.mu != nil {
+		sr.mu.RLock()
+		defer sr.mu.RUnlock()
+	}
+	var normalizedPaths []string
+	for _, normalized := range sr.NormalizedPaths {
+		normalizedPaths = append(normalizedPaths, normalized)
+	}
+	return normalizedPaths
+}
+
+// shouldExclude checks if a path should be excluded from scanning.
 func (s *Scanner) shouldExclude(path string) (bool, error) {
 	for _, pattern := range s.excludePatterns {
 		matched, err := filepath.Match(pattern, path)
@@ -168,22 +243,16 @@ func (s *Scanner) shouldExclude(path string) (bool, error) {
 	return false, nil
 }
 
-// BuildrootToInstalled converts a buildroot path to an installed path for Syft coordinate matching.
-//
-// It removes the buildroot prefix and ensures the path starts with "/" for consistency
-// with Syft's file coordinate system.
+// BuildrootToInstalled converts a buildroot path to an installed path.
 func BuildrootToInstalled(buildrootFile, buildrootPath string) (string, error) {
-	if !strings.HasPrefix(buildrootFile, buildrootPath) {
-		return "", fmt.Errorf("file %s is not under buildroot %s", buildrootFile, buildrootPath)
+	cleanFile := filepath.Clean(buildrootFile)
+	cleanBuildroot := filepath.Clean(buildrootPath)
+	rel, err := filepath.Rel(cleanBuildroot, cleanFile)
+	if err != nil || strings.HasPrefix(rel, "..") {
+		return "", fmt.Errorf("path outside buildroot: %s", buildrootFile)
 	}
 
-	relativePath := strings.TrimPrefix(buildrootFile, buildrootPath)
-
-	if !strings.HasPrefix(relativePath, "/") {
-		relativePath = "/" + relativePath
-	}
-
-	installedPath := filepath.Clean(relativePath)
+	installedPath := filepath.Clean("/" + rel)
 
 	return installedPath, nil
 }

--- a/sbomtool/internal/buildroot/scanner_bench_test.go
+++ b/sbomtool/internal/buildroot/scanner_bench_test.go
@@ -1,0 +1,60 @@
+package buildroot
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func createTestBuildroot(b *testing.B, fileCount int) string {
+	b.Helper()
+	dir, err := os.MkdirTemp("", "scanner-bench")
+	if err != nil {
+		b.Fatal(err)
+	}
+	for i := 0; i < fileCount; i++ {
+		subdir := filepath.Join(dir, "usr", "lib")
+		if err := os.MkdirAll(subdir, 0755); err != nil {
+			b.Fatal(err)
+		}
+		if err := os.WriteFile(filepath.Join(subdir, fmt.Sprintf("file_%d.txt", i)), []byte("x"), 0644); err != nil {
+			b.Fatal(err)
+		}
+	}
+	return dir
+}
+
+func BenchmarkScanDirectory_Small(b *testing.B) {
+	dir := createTestBuildroot(b, 100)
+	defer os.RemoveAll(dir)
+	scanner := NewScanner(10, nil)
+	b.ResetTimer()
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		_, _ = scanner.ScanDirectory(dir)
+	}
+}
+
+func BenchmarkScanDirectory_Medium(b *testing.B) {
+	dir := createTestBuildroot(b, 1000)
+	defer os.RemoveAll(dir)
+	scanner := NewScanner(10, nil)
+	b.ResetTimer()
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		_, _ = scanner.ScanDirectory(dir)
+	}
+}
+
+func BenchmarkGetNormalizedPaths(b *testing.B) {
+	dir := createTestBuildroot(b, 500)
+	defer os.RemoveAll(dir)
+	scanner := NewScanner(10, nil)
+	result, _ := scanner.ScanDirectory(dir)
+	b.ResetTimer()
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		_ = result.GetNormalizedPaths()
+	}
+}

--- a/sbomtool/internal/buildroot/scanner_test.go
+++ b/sbomtool/internal/buildroot/scanner_test.go
@@ -3,6 +3,7 @@ package buildroot
 import (
 	"os"
 	"path/filepath"
+	"sync"
 	"testing"
 )
 
@@ -463,6 +464,7 @@ func TestGetNormalizedPaths(t *testing.T) {
 			"/tmp/buildroot/usr/lib/lib.so": "/usr/lib/lib.so",
 			"/tmp/buildroot/etc/config":     "/etc/config",
 		},
+		mu: &sync.RWMutex{},
 	}
 
 	normalizedPaths := result.GetNormalizedPaths()

--- a/sbomtool/internal/commands/generate/generate.go
+++ b/sbomtool/internal/commands/generate/generate.go
@@ -11,6 +11,7 @@ import (
 	"github.com/anchore/syft/syft/format/cyclonedxjson"
 	"github.com/anchore/syft/syft/format/spdxjson"
 	"github.com/anchore/syft/syft/sbom"
+	"golang.org/x/sync/errgroup"
 )
 
 // closeFile safely closes a file handle and logs any close errors without returning them.
@@ -112,20 +113,32 @@ func Generate(name string, spdx bool, cyclonedx bool, buildDir string, outDir st
 	// Set the source name from the --name parameter so it appears in metadata.component
 	sbomData.Source.Name = name
 
+	var g errgroup.Group
+
 	if spdx {
-		slog.Info("Generating SPDX SBOM", "name", name)
-		if err := createSpdxSbom(*sbomData, name, outDir); err != nil {
-			return false, err
-		}
-		slog.Info("SPDX SBOM generated successfully")
+		g.Go(func() error {
+			slog.Info("Generating SPDX SBOM", "name", name)
+			if err := createSpdxSbom(*sbomData, name, outDir); err != nil {
+				return err
+			}
+			slog.Info("SPDX SBOM generated successfully")
+			return nil
+		})
 	}
 
 	if cyclonedx {
-		slog.Info("Generating CycloneDX SBOM", "name", name)
-		if err := createCyclonedxSbom(*sbomData, name, outDir); err != nil {
-			return false, err
-		}
-		slog.Info("CycloneDX SBOM generated successfully")
+		g.Go(func() error {
+			slog.Info("Generating CycloneDX SBOM", "name", name)
+			if err := createCyclonedxSbom(*sbomData, name, outDir); err != nil {
+				return err
+			}
+			slog.Info("CycloneDX SBOM generated successfully")
+			return nil
+		})
+	}
+
+	if err := g.Wait(); err != nil {
+		return false, err
 	}
 
 	slog.Info("All requested SBOM formats generated successfully")

--- a/sbomtool/internal/commands/generate/generate_bench_test.go
+++ b/sbomtool/internal/commands/generate/generate_bench_test.go
@@ -1,0 +1,69 @@
+package generate
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/anchore/syft/syft"
+	"github.com/anchore/syft/syft/sbom"
+)
+
+func createTestSBOM(b *testing.B, dir string) sbom.SBOM {
+	b.Helper()
+	gsc := syft.DefaultGetSourceConfig()
+	src, err := syft.GetSource(context.Background(), dir, gsc)
+	if err != nil {
+		b.Fatal(err)
+	}
+	sc := syft.DefaultCreateSBOMConfig()
+	s, err := sc.Create(context.Background(), src)
+	if err != nil {
+		b.Fatal(err)
+	}
+	return *s
+}
+
+func setupBenchDir(b *testing.B, fileCount int) (string, string) {
+	b.Helper()
+	buildDir, err := os.MkdirTemp("", "gen-bench-build")
+	if err != nil {
+		b.Fatal(err)
+	}
+	outDir, err := os.MkdirTemp("", "gen-bench-out")
+	if err != nil {
+		b.Fatal(err)
+	}
+	for i := 0; i < fileCount; i++ {
+		if err := os.WriteFile(filepath.Join(buildDir, fmt.Sprintf("file%d", i)), []byte("x"), 0644); err != nil {
+			b.Fatal(err)
+		}
+	}
+	return buildDir, outDir
+}
+
+func BenchmarkCreateSpdxSbom_Small(b *testing.B) {
+	buildDir, outDir := setupBenchDir(b, 10)
+	defer os.RemoveAll(buildDir)
+	defer os.RemoveAll(outDir)
+	s := createTestSBOM(b, buildDir)
+	b.ResetTimer()
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		_ = createSpdxSbom(s, "bench", outDir)
+	}
+}
+
+func BenchmarkCreateCyclonedxSbom_Small(b *testing.B) {
+	buildDir, outDir := setupBenchDir(b, 10)
+	defer os.RemoveAll(buildDir)
+	defer os.RemoveAll(outDir)
+	s := createTestSBOM(b, buildDir)
+	b.ResetTimer()
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		_ = createCyclonedxSbom(s, "bench", outDir)
+	}
+}

--- a/sbomtool/internal/commands/merge/merge.go
+++ b/sbomtool/internal/commands/merge/merge.go
@@ -5,14 +5,17 @@
 package merge
 
 import (
+	"context"
 	"fmt"
 	"log/slog"
+	"runtime"
 	"time"
 
 	"github.com/anchore/syft/syft/artifact"
 	"github.com/anchore/syft/syft/pkg"
 	"github.com/anchore/syft/syft/sbom"
 	"github.com/anchore/syft/syft/source"
+	"golang.org/x/sync/errgroup"
 
 	"github.com/bottlerocket-os/bottlerocket-sdk/sbomtool/go/internal/deduplication"
 	"github.com/bottlerocket-os/bottlerocket-sdk/sbomtool/go/internal/processor"
@@ -111,30 +114,53 @@ func validateInputs(config MergeConfig, inputFiles []string) error {
 	return nil
 }
 
-// loadSBOMs loads all SBOM files and validates format consistency.
+// loadSBOMs loads all SBOM files in parallel (mixed formats allowed).
+// Thread-safety: Syft's LoadSBOM is safe for concurrent use as it only performs
+// independent file I/O operations without shared mutable state.
 func loadSBOMs(inputFiles []string) ([]*sbom.SBOM, string, error) {
-	var sboms []*sbom.SBOM
-	var commonFormat string
-
-	for i, file := range inputFiles {
-		slog.Debug("Loading SBOM file", "file", file, "index", i+1)
-
-		s, format, err := processor.LoadSBOM(file)
-		if err != nil {
-			return nil, "", fmt.Errorf("failed to load SBOM from %s: %w", file, err)
-		}
-
-		if i == 0 {
-			commonFormat = format
-		} else if format != commonFormat {
-			return nil, "", fmt.Errorf("format mismatch: expected %s, got %s in file %s", commonFormat, format, file)
-		}
-
-		sboms = append(sboms, s)
+	numWorkers := runtime.GOMAXPROCS(0)
+	if numWorkers > len(inputFiles) {
+		numWorkers = len(inputFiles)
 	}
 
-	slog.Info("All SBOM files loaded successfully", "count", len(sboms), "format", commonFormat)
-	return sboms, commonFormat, nil
+	sboms := make([]*sbom.SBOM, len(inputFiles))
+	formats := make([]string, len(inputFiles))
+
+	g, _ := errgroup.WithContext(context.Background())
+	g.SetLimit(numWorkers)
+
+	for i := range inputFiles {
+		i := i
+		g.Go(func() error {
+			s, format, err := processor.LoadSBOM(inputFiles[i])
+			if err != nil {
+				return fmt.Errorf("failed to load %s: %w", inputFiles[i], err)
+			}
+			sboms[i] = s
+			formats[i] = format
+			return nil
+		})
+	}
+
+	if err := g.Wait(); err != nil {
+		return nil, "", err
+	}
+
+	// Find first non-empty format for output format detection
+	var detectedFormat string
+	for _, f := range formats {
+		if f != "" {
+			detectedFormat = f
+			break
+		}
+	}
+
+	if detectedFormat == "" {
+		return nil, "", fmt.Errorf("no valid SBOM format detected from input files")
+	}
+
+	slog.Info("All SBOM files loaded successfully", "count", len(sboms))
+	return sboms, detectedFormat, nil
 }
 
 // sourceToPackage converts an SBOM's Source (metadata.component) to a package.
@@ -155,6 +181,20 @@ func sourceToPackage(src source.Description) *pkg.Package {
 	return &p
 }
 
+// extractPackageFromEndpoint extracts a package from a relationship endpoint.
+func extractPackageFromEndpoint(endpoint artifact.Identifiable) (pkg.Package, bool) {
+	if endpoint == nil {
+		return pkg.Package{}, false
+	}
+	if p, ok := endpoint.(pkg.Package); ok {
+		return p, true
+	}
+	if p, ok := endpoint.(*pkg.Package); ok && p != nil {
+		return *p, true
+	}
+	return pkg.Package{}, false
+}
+
 // mergeSBOMs combines SBOM metadata and extracts all packages and relationships.
 // Each input SBOM's Source (metadata.component) is converted to a package to preserve
 // the subject of each SBOM in the merged output. Contains relationships are created
@@ -169,17 +209,31 @@ func mergeSBOMs(sboms []*sbom.SBOM) (*sbom.SBOM, []pkg.Package, []artifact.Relat
 		Descriptor: sboms[0].Descriptor,
 	}
 
-	var allPackages []pkg.Package
-	var allRelationships []artifact.Relationship
+	// Estimate capacity for pre-allocation
+	var totalPkgs, totalRels int
+	for _, s := range sboms {
+		totalPkgs += s.Artifacts.Packages.PackageCount()
+		totalRels += len(s.Relationships)
+	}
+	totalPkgs += len(sboms) // Account for source packages
+
+	// Track seen package IDs to avoid duplicates from relationship endpoints
+	seenIDs := make(map[artifact.ID]struct{}, totalPkgs)
+	allPackages := make([]pkg.Package, 0, totalPkgs)
+	allRelationships := make([]artifact.Relationship, 0, totalRels)
 
 	// Collect all packages and relationships, including Source as a package
 	for _, s := range sboms {
 		sbomPackages := s.Artifacts.Packages.Sorted()
-		allPackages = append(allPackages, sbomPackages...)
+		for _, p := range sbomPackages {
+			seenIDs[p.ID()] = struct{}{}
+			allPackages = append(allPackages, p)
+		}
 		allRelationships = append(allRelationships, s.Relationships...)
 
 		// Convert Source (metadata.component) to a package and create contains relationships
 		if srcPkg := sourceToPackage(s.Source); srcPkg != nil {
+			seenIDs[srcPkg.ID()] = struct{}{}
 			allPackages = append(allPackages, *srcPkg)
 
 			// Create "contains" relationships from source to each package in this SBOM
@@ -189,6 +243,22 @@ func mergeSBOMs(sboms []*sbom.SBOM) (*sbom.SBOM, []pkg.Package, []artifact.Relat
 					To:   p,
 					Type: artifact.ContainsRelationship,
 				})
+			}
+		}
+	}
+
+	// Extract packages from relationship endpoints (only if not already seen)
+	for _, rel := range allRelationships {
+		if p, ok := extractPackageFromEndpoint(rel.From); ok {
+			if _, seen := seenIDs[p.ID()]; !seen {
+				seenIDs[p.ID()] = struct{}{}
+				allPackages = append(allPackages, p)
+			}
+		}
+		if p, ok := extractPackageFromEndpoint(rel.To); ok {
+			if _, seen := seenIDs[p.ID()]; !seen {
+				seenIDs[p.ID()] = struct{}{}
+				allPackages = append(allPackages, p)
 			}
 		}
 	}
@@ -205,7 +275,42 @@ func createFinalSBOM(base *sbom.SBOM, canonicalPackages map[string]*pkg.Package,
 	// Create new package collection
 	collection := pkg.NewCollection()
 	for _, p := range canonicalPackages {
-		collection.Add(*p)
+		if p != nil {
+			collection.Add(*p)
+		}
+	}
+
+	// Build map from ID to package pointer in collection
+	idToCollectionPkg := make(map[artifact.ID]pkg.Package, len(canonicalPackages))
+	for p := range collection.Enumerate() {
+		idToCollectionPkg[p.ID()] = p
+	}
+
+	// Update relationship endpoints to point to collection packages
+	validRelationships := make([]artifact.Relationship, 0, len(relationships))
+	for _, rel := range relationships {
+		// Nil checks before calling ID()
+		if rel.From == nil || rel.To == nil {
+			continue
+		}
+
+		newRel := rel
+
+		// Update From endpoint
+		if fromPkg, ok := idToCollectionPkg[rel.From.ID()]; ok {
+			newRel.From = fromPkg
+		} else {
+			continue // Skip if From not in collection
+		}
+
+		// Update To endpoint
+		if toPkg, ok := idToCollectionPkg[rel.To.ID()]; ok {
+			newRel.To = toPkg
+		} else {
+			continue // Skip if To not in collection
+		}
+
+		validRelationships = append(validRelationships, newRel)
 	}
 
 	return &sbom.SBOM{
@@ -213,6 +318,6 @@ func createFinalSBOM(base *sbom.SBOM, canonicalPackages map[string]*pkg.Package,
 		Artifacts: sbom.Artifacts{
 			Packages: collection,
 		},
-		Relationships: relationships,
+		Relationships: validRelationships,
 	}
 }

--- a/sbomtool/internal/commands/merge/merge_test.go
+++ b/sbomtool/internal/commands/merge/merge_test.go
@@ -191,8 +191,8 @@ func TestCreateFinalSBOM(t *testing.T) {
 
 	relationships := []artifact.Relationship{
 		{
-			From: pkg.Package{Name: "pkg1"},
-			To:   pkg.Package{Name: "pkg2"},
+			From: *canonicalPackages["key1"],
+			To:   *canonicalPackages["key2"],
 			Type: artifact.DependencyOfRelationship,
 		},
 	}

--- a/sbomtool/internal/deduplication/deduplicator.go
+++ b/sbomtool/internal/deduplication/deduplicator.go
@@ -8,6 +8,7 @@ package deduplication
 import (
 	"fmt"
 	"log/slog"
+	"slices"
 	"strings"
 	"time"
 
@@ -15,6 +16,8 @@ import (
 	"github.com/anchore/syft/syft/cpe"
 	"github.com/anchore/syft/syft/file"
 	"github.com/anchore/syft/syft/pkg"
+
+	"github.com/bottlerocket-os/bottlerocket-sdk/sbomtool/go/internal/unionfind"
 )
 
 // DeduplicationResult contains the results of package deduplication.
@@ -61,7 +64,7 @@ func DeduplicatePackages(packages []pkg.Package) *DeduplicationResult {
 
 	for i := range realPackages {
 		p := &realPackages[i]
-		key := generateCanonicalKey(*p)
+		key := generateCanonicalKey(p)
 		keyToPackages[key] = append(keyToPackages[key], p)
 	}
 
@@ -107,26 +110,49 @@ func DeduplicatePackages(packages []pkg.Package) *DeduplicationResult {
 // UpdateRelationships rebuilds relationships using canonical packages from deduplication.
 func UpdateRelationships(relationships []artifact.Relationship, canonicalPackages map[string]*pkg.Package, idMapping map[string]string) []artifact.Relationship {
 	updated := make([]artifact.Relationship, 0, len(relationships))
-	relationshipSet := make(map[string]bool)
+	relationshipSet := make(map[string]bool, len(relationships))
 
-	idToCanonical := make(map[string]*pkg.Package)
+	idToCanonical := make(map[string]*pkg.Package, len(canonicalPackages))
+	cpeToCanonical := make(map[string]*pkg.Package, len(canonicalPackages))
+	nvtToCanonical := make(map[string]*pkg.Package, len(canonicalPackages))
+	prefixToCanonical := make(map[string]*pkg.Package, len(canonicalPackages))
 	for _, canonical := range canonicalPackages {
+		if canonical == nil {
+			continue
+		}
 		idToCanonical[string(canonical.ID())] = canonical
+		for _, c := range canonical.CPEs {
+			cpeToCanonical[c.Attributes.String()] = canonical
+		}
+		nvtKey := nvtKeyFromPackage(canonical)
+		nvtToCanonical[nvtKey] = canonical
+		// Build prefix lookup: SPDX ID without trailing hash
+		idStr := string(canonical.ID())
+		if idx := strings.LastIndex(idStr, "-"); idx > 0 {
+			prefixToCanonical[idStr[:idx]] = canonical
+		}
 	}
 
 	for _, rel := range relationships {
+		if rel.From == nil || rel.To == nil {
+			continue
+		}
 		newRel := rel
 
 		if canonicalID, exists := idMapping[string(rel.From.ID())]; exists {
 			if canonical, found := idToCanonical[canonicalID]; found {
 				newRel.From = canonical
 			}
+		} else {
+			newRel.From = resolveEndpoint(rel.From, cpeToCanonical, nvtToCanonical, prefixToCanonical)
 		}
 
 		if canonicalID, exists := idMapping[string(rel.To.ID())]; exists {
 			if canonical, found := idToCanonical[canonicalID]; found {
 				newRel.To = canonical
 			}
+		} else {
+			newRel.To = resolveEndpoint(rel.To, cpeToCanonical, nvtToCanonical, prefixToCanonical)
 		}
 
 		relKey := fmt.Sprintf("%s|%s|%s", newRel.From.ID(), newRel.To.ID(), newRel.Type)
@@ -145,8 +171,54 @@ func UpdateRelationships(relationships []artifact.Relationship, canonicalPackage
 	return updated
 }
 
+// resolveEndpoint attempts to find a canonical package for a relationship endpoint.
+func resolveEndpoint(endpoint artifact.Identifiable, cpeToCanonical, nvtToCanonical, prefixToCanonical map[string]*pkg.Package) artifact.Identifiable {
+	if endpoint == nil {
+		return nil
+	}
+	var p *pkg.Package
+	switch v := endpoint.(type) {
+	case *pkg.Package:
+		p = v
+	case pkg.Package:
+		p = &v
+	default:
+		// Not a pkg.Package - try SPDX ID prefix matching
+		idStr := string(endpoint.ID())
+		if idx := strings.LastIndex(idStr, "-"); idx > 0 {
+			if canonical, found := prefixToCanonical[idStr[:idx]]; found {
+				return canonical
+			}
+		}
+		return endpoint
+	}
+
+	// Try CPE lookup
+	for _, c := range p.CPEs {
+		if canonical, found := cpeToCanonical[c.Attributes.String()]; found {
+			return canonical
+		}
+	}
+
+	// Try NVT lookup
+	nvtKey := nvtKeyFromPackage(p)
+	if canonical, found := nvtToCanonical[nvtKey]; found {
+		return canonical
+	}
+
+	return endpoint
+}
+
+// nvtKeyFromPackage creates a name+version+type key for package lookup.
+func nvtKeyFromPackage(p *pkg.Package) string {
+	if p == nil {
+		return ""
+	}
+	return fmt.Sprintf("%s|%s|%s", strings.ToLower(strings.TrimSpace(p.Name)), normalizeVersion(p.Version), string(p.Type))
+}
+
 // generateCanonicalKey creates a unique key for package deduplication.
-func generateCanonicalKey(p pkg.Package) string {
+func generateCanonicalKey(p *pkg.Package) string {
 	// Use CPE as primary deduplication key when available
 	if len(p.CPEs) > 0 {
 		return p.CPEs[0].Attributes.String()
@@ -263,64 +335,87 @@ func isUnknownOrNoAssertion(value string) bool {
 	return normalized == "unknown" || normalized == "noassertion" || normalized == ""
 }
 
-// mergeOverlappingCPEGroups merges package groups that have overlapping CPEs
+// mergeOverlappingCPEGroups merges package groups that share CPEs using Union-Find.
+//
+// Problem: Packages from different SBOMs may represent the same software but have
+// different canonical keys (e.g., different CPE variants). If any CPE appears in
+// multiple groups, those groups should be merged.
+//
+// Solution: Union-Find (disjoint set) provides O(α(n)) amortized operations where
+// α is the inverse Ackermann function (effectively constant). This replaces the
+// previous O(n²) pairwise comparison approach.
+//
+// Algorithm:
+//  1. Build an inverted index: CPE string -> list of group indices that contain it
+//  2. Initialize Union-Find with each group as its own set
+//  3. For each CPE that appears in multiple groups, union those groups together
+//  4. Collect all packages belonging to the same root into merged groups
 func mergeOverlappingCPEGroups(keyToPackages map[string][]*pkg.Package) map[string][]*pkg.Package {
+	if len(keyToPackages) == 0 {
+		return keyToPackages
+	}
+
+	// Convert map to slices for index-based Union-Find operations
+	// Sort keys for deterministic results
+	keys := make([]string, 0, len(keyToPackages))
+	for k := range keyToPackages {
+		keys = append(keys, k)
+	}
+	slices.Sort(keys)
 	groups := make([][]*pkg.Package, 0, len(keyToPackages))
-	for _, group := range keyToPackages {
-		groups = append(groups, group)
+	for _, k := range keys {
+		groups = append(groups, keyToPackages[k])
 	}
 
-	merged := make([][]*pkg.Package, 0)
-	used := make([]bool, len(groups))
-
-	for i, group1 := range groups {
-		if used[i] {
-			continue
-		}
-
-		mergedGroup := make([]*pkg.Package, len(group1))
-		copy(mergedGroup, group1)
-		used[i] = true
-
-		for j := i + 1; j < len(groups); j++ {
-			if used[j] {
-				continue
-			}
-
-			if hasOverlappingCPEs(mergedGroup, groups[j]) {
-				mergedGroup = append(mergedGroup, groups[j]...)
-				used[j] = true
+	// Step 1: Build inverted index from CPE -> group indices
+	cpeToGroups := make(map[string][]int)
+	for idx, group := range groups {
+		for _, p := range group {
+			for _, c := range p.CPEs {
+				cpeStr := c.Attributes.String()
+				cpeToGroups[cpeStr] = append(cpeToGroups[cpeStr], idx)
 			}
 		}
-
-		merged = append(merged, mergedGroup)
 	}
 
+	// Step 2: Initialize Union-Find
+	uf := unionfind.New(len(groups))
+
+	// Step 3: Union all groups that share any CPE
+	for _, indices := range cpeToGroups {
+		for i := 1; i < len(indices); i++ {
+			uf.Union(indices[0], indices[i], keys)
+		}
+	}
+
+	// Step 3b: Build inverted index from name+version+type -> group indices
+	// This catches packages that should merge but have different/no CPEs
+	nvtToGroups := make(map[string][]int)
+	for idx, group := range groups {
+		for _, p := range group {
+			nvtKey := fmt.Sprintf("%s|%s|%s", strings.ToLower(strings.TrimSpace(p.Name)), normalizeVersion(p.Version), string(p.Type))
+			nvtToGroups[nvtKey] = append(nvtToGroups[nvtKey], idx)
+		}
+	}
+
+	// Step 3c: Union all groups that share name+version+type
+	for _, indices := range nvtToGroups {
+		for i := 1; i < len(indices); i++ {
+			uf.Union(indices[0], indices[i], keys)
+		}
+	}
+
+	// Step 4: Collect packages by their root group
+	merged := make(map[int][]*pkg.Package)
+	for i, group := range groups {
+		root := uf.Find(i)
+		merged[root] = append(merged[root], group...)
+	}
+
+	// Convert back to map keyed by the root's canonical key
 	result := make(map[string][]*pkg.Package)
-	for i, group := range merged {
-		key := fmt.Sprintf("merged_group_%d", i)
-		result[key] = group
+	for root, pkgs := range merged {
+		result[keys[root]] = pkgs
 	}
-
 	return result
-}
-
-// hasOverlappingCPEs checks if two package groups have any overlapping CPEs
-func hasOverlappingCPEs(group1, group2 []*pkg.Package) bool {
-	cpes1 := make(map[string]bool)
-	for _, pkg := range group1 {
-		for _, cpe := range pkg.CPEs {
-			cpes1[cpe.Attributes.String()] = true
-		}
-	}
-
-	for _, pkg := range group2 {
-		for _, cpe := range pkg.CPEs {
-			if cpes1[cpe.Attributes.String()] {
-				return true
-			}
-		}
-	}
-
-	return false
 }

--- a/sbomtool/internal/deduplication/deduplicator_test.go
+++ b/sbomtool/internal/deduplication/deduplicator_test.go
@@ -232,7 +232,7 @@ func TestGenerateCanonicalKey_CPEPreferred(t *testing.T) {
 		},
 	}
 
-	key := generateCanonicalKey(p)
+	key := generateCanonicalKey(&p)
 
 	assert.Equal(t, "cpe:2.3:a:test:test:1.0:*:*:*:*:*:*:*", key)
 	assert.NotContains(t, key, "fallback:")
@@ -249,7 +249,7 @@ func TestGenerateCanonicalKey_FallbackStrategy(t *testing.T) {
 		Type:    pkg.RpmPkg,
 	}
 
-	key := generateCanonicalKey(p)
+	key := generateCanonicalKey(&p)
 
 	assert.Equal(t, "test|1.0|rpm", key)
 }

--- a/sbomtool/internal/processor/processor.go
+++ b/sbomtool/internal/processor/processor.go
@@ -4,14 +4,17 @@
 package processor
 
 import (
+	"context"
 	"fmt"
 	"log/slog"
 	"os"
+	"strings"
 
 	"github.com/anchore/syft/syft/format"
 	"github.com/anchore/syft/syft/format/cyclonedxjson"
 	"github.com/anchore/syft/syft/pkg"
 	"github.com/anchore/syft/syft/sbom"
+	"golang.org/x/sync/errgroup"
 )
 
 // LoadSBOM loads an existing SBOM using Syft's format detection.
@@ -89,4 +92,35 @@ func countPackagesByType(catalog *pkg.Collection, pkgType pkg.Type) int {
 		}
 	}
 	return count
+}
+
+// SaveSBOMBothFormats saves the SBOM in both SPDX and CycloneDX formats in parallel.
+func SaveSBOMBothFormats(ctx context.Context, s *sbom.SBOM, basePath string) error {
+	base := strings.TrimSuffix(basePath, ".json")
+
+	g, ctx := errgroup.WithContext(ctx)
+
+	formats := []struct {
+		name string
+		id   string
+	}{
+		{"spdx", "spdx-json"},
+		{"cyclonedx", "cyclonedx-json"},
+	}
+
+	for _, f := range formats {
+		name, formatID := f.name, f.id
+		g.Go(func() error {
+			if err := ctx.Err(); err != nil {
+				return err
+			}
+			path := fmt.Sprintf("%s-%s.json", base, name)
+			if err := SaveSBOM(s, path, formatID); err != nil {
+				return fmt.Errorf("%s: %w", name, err)
+			}
+			return nil
+		})
+	}
+
+	return g.Wait()
 }

--- a/sbomtool/internal/unionfind/unionfind.go
+++ b/sbomtool/internal/unionfind/unionfind.go
@@ -1,0 +1,51 @@
+// Package unionfind implements a disjoint-set data structure with path compression.
+package unionfind
+
+// UnionFind implements a disjoint-set data structure.
+type UnionFind struct {
+	parent []int
+}
+
+// New creates a UnionFind with n elements.
+func New(n int) *UnionFind {
+	parent := make([]int, n)
+	for i := range parent {
+		parent[i] = i
+	}
+	return &UnionFind{parent: parent}
+}
+
+// Find returns the root of the set containing x, with path compression.
+// Returns -1 if x is out of bounds.
+func (uf *UnionFind) Find(x int) int {
+	if x < 0 || x >= len(uf.parent) {
+		return -1
+	}
+	if uf.parent[x] != x {
+		uf.parent[x] = uf.Find(uf.parent[x])
+	}
+	return uf.parent[x]
+}
+
+// Union merges the sets containing x and y.
+// Uses keys for lexicographic comparison to ensure deterministic root selection.
+// This trades optimal tree height (rank-based union) for deterministic output,
+// which is acceptable given our small dataset sizes.
+// No-op if x or y is out of bounds.
+func (uf *UnionFind) Union(x, y int, keys []string) {
+	if x < 0 || x >= len(uf.parent) || y < 0 || y >= len(uf.parent) {
+		return
+	}
+	px, py := uf.Find(x), uf.Find(y)
+	if px != py {
+		// keys must have same length as parent
+		if px == -1 || py == -1 || keys == nil || px >= len(keys) || py >= len(keys) {
+			return
+		}
+		if keys[px] < keys[py] {
+			uf.parent[py] = px
+		} else {
+			uf.parent[px] = py
+		}
+	}
+}

--- a/sbomtool/internal/unionfind/unionfind_test.go
+++ b/sbomtool/internal/unionfind/unionfind_test.go
@@ -1,0 +1,96 @@
+package unionfind
+
+import "testing"
+
+func TestBasicUnion(t *testing.T) {
+	keys := []string{"a", "b"}
+	uf := New(2)
+	uf.Union(0, 1, keys)
+	if uf.Find(0) != uf.Find(1) {
+		t.Error("elements should be in same set")
+	}
+}
+
+func TestTransitiveUnion(t *testing.T) {
+	keys := []string{"a", "b", "c"}
+	uf := New(3)
+	uf.Union(0, 1, keys)
+	uf.Union(1, 2, keys)
+	if uf.Find(0) != uf.Find(2) {
+		t.Error("a and c should be in same set via b")
+	}
+}
+
+func TestDeterminism(t *testing.T) {
+	keys := []string{"z", "a", "m"}
+	uf1 := New(3)
+	uf1.Union(0, 1, keys)
+	uf1.Union(1, 2, keys)
+
+	uf2 := New(3)
+	uf2.Union(0, 1, keys)
+	uf2.Union(1, 2, keys)
+
+	for i := 0; i < 3; i++ {
+		if uf1.Find(i) != uf2.Find(i) {
+			t.Error("same operations should produce same roots")
+		}
+	}
+}
+
+func TestPathCompression(t *testing.T) {
+	keys := []string{"a", "b", "c", "d"}
+	uf := New(4)
+	uf.Union(0, 1, keys)
+	uf.Union(1, 2, keys)
+	uf.Union(2, 3, keys)
+	root := uf.Find(3)
+	// After find, 3 should point directly to root
+	if uf.parent[3] != root {
+		t.Error("path compression should update parent")
+	}
+}
+
+func TestEmpty(t *testing.T) {
+	uf := New(0)
+	// Should not panic
+	_ = uf
+}
+
+func TestSingleElement(t *testing.T) {
+	uf := New(1)
+	if uf.Find(0) != 0 {
+		t.Error("single element should be its own root")
+	}
+}
+
+func TestOutOfBounds(t *testing.T) {
+	uf := New(3)
+	keys := []string{"a", "b", "c"}
+
+	// Find with invalid indices returns -1
+	if uf.Find(-1) != -1 {
+		t.Error("Find(-1) should return -1")
+	}
+	if uf.Find(3) != -1 {
+		t.Error("Find(n) where n >= size should return -1")
+	}
+	if uf.Find(100) != -1 {
+		t.Error("Find(100) should return -1")
+	}
+
+	// Union with invalid indices is a no-op (should not panic)
+	uf.Union(-1, 0, keys)
+	uf.Union(0, -1, keys)
+	uf.Union(3, 0, keys)
+	uf.Union(0, 3, keys)
+	uf.Union(100, 0, keys)
+
+	// Union with nil keys doesn't panic
+	uf.Union(0, 1, nil)
+
+	// Verify state unchanged after invalid operations
+	if uf.Find(0) != 0 || uf.Find(1) != 1 || uf.Find(2) != 2 {
+		t.Error("invalid operations should not change state")
+	}
+}


### PR DESCRIPTION
<!--
Tips:
- Please read the CONTRIBUTING document to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->

**Issue number:** 326



**Description of changes:**
Modified SBOM generation to be slightly faster (estimated 1-3 minutes shaved off core kit generation) and changed the merge algorithm from an O(n^2) one while introducing additional parallelization.

Also, found that some relationships were being dropped during merge so fixed that, making the merged SBOM less flat.


**Testing done:**

Extracted all SBOMs from the core kit and ran as a benchmark. See below:

Before:
```
Building sbomtool...
Extracting SBOMs from RPMs...
Found 262 SBOM RPMs
Extracted: 125 SPDX, 125 CycloneDX (71M)

=== Benchmarks ===

--- SPDX only (125 files) ---
  Wall time: 254.95s

--- CycloneDX only (125 files) ---
  Wall time: 246.39s
```

After:
```
Building sbomtool...                                                                                                                                                                          
Extracting SBOMs from RPMs...                                                                                                                                                                 
Found 262 SBOM RPMs                                                                                                                                                                           
Extracted: 125 SPDX, 125 CycloneDX (71M)                                                                                                                                                      
                                                                                                                                                                                              
=== Benchmarks ===                                                                                                                                                                            
                                                                                                                                                                                              
--- SPDX only (125 files) ---                                                                                                                                                                 
  Wall time: 3.05s                                                                                                                                                                            
  Output: 4009 packages, 8.4M                                                                                                                                                                 
                                                                                                                                                                                              
--- CycloneDX only (125 files) ---                                                                                                                                                            
  Wall time: 1.77s                                                                                                                                                                            
  Output: 3883 packages, 8.6M                                                                                                                                                                 
                                                                                                                                                                                              
--- Mixed SPDX+CycloneDX (250 files) ---                                                                                                                                                      
  Wall time: 4.23s                                                                                                                                                                            
  Output: 4021 packages, 9.5M                                                                                                                                                                 
                                                                                                                                                                                              
--- Dual output (both formats) ---                                                                                                                                                            
  Wall time: 4.25s                                                                                                                                                                            
  Outputs:                                                                                                                                                                                    
    /tmp/sbomtool-benchmark-991667/both-cyclonedx.json: 7.6M                                                                                                                                  
    /tmp/sbomtool-benchmark-991667/both-spdx.json: 9.5M                                                                                                                                       
                                                                                                                                                                                              
=== Validation ===                                                                                                                                                                            
                                                                                                                                                                                              
Package counts:                                                                                                                                                                               
  SPDX only:      4009                                                                                                                                                                        
  CycloneDX only: 3883
  Mixed:          4021
  Both (SPDX):    4021
  Both (CDX):     4020
```


**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
