### PR TITLE
macros: add configurable SBOM build directory

### DIFF
--- a/macros/shared
+++ b/macros/shared
@@ -332,9 +332,11 @@ This package provides SBOM files for %{name}.\
 %[ 0%{?_enable_sbom_packages} > 0 ? "%{?buildsubdir:%{expand:%%global __sbom_package 1}%(echo "%{_sbom_template}" > %{specpartsdir}/rpm-sbom.specpart)}" : "" ]\
 %{nil}
 
+%_cross_sbom_build_dir %{_builddir}
+
 %cross_generate_sbom \
   mkdir -p %{_builddir}/sbom-temp \
-  sbomtool generate --name %{_uncross_name} --out-dir %{_builddir}/sbom-temp --build-dir %{_builddir} --spdx --cyclonedx
+  sbomtool generate --name %{_uncross_name} --out-dir %{_builddir}/sbom-temp --build-dir %{_cross_sbom_build_dir} --spdx --cyclonedx
 
 %cross_install_sbom \
   install -d %{buildroot}%{_cross_sbom_package_dir} \

--- a/macros/shared
+++ b/macros/shared
@@ -299,7 +299,6 @@ CROSS_CMAKE_TOOLCHAIN_EOF\
 %_sbom_template \
 %ifnarch noarch\
 %global __sbom_package 1\
-%{?buildsubdir:%%global __sbom_package 1}\
 %package sbom\
 Summary: SBOM (Software Bill of Materials) for %{name}\
 AutoReqProv: 0\
@@ -316,7 +315,6 @@ This package provides SBOM files for %{name}.\
 %sbom_package \
 %ifnarch noarch\
 %global __sbom_package 1\
-%{?buildsubdir:%%global __sbom_package 1}\
 %_sbom_template\
 %endif\
 %{nil}
@@ -329,7 +327,7 @@ This package provides SBOM files for %{name}.\
 %__spec_install_template\
 %{__spec_install_pre}\
 %[ 0%{?_enable_debug_packages} > 0 ? "%{?buildsubdir:%(echo "%{debug_package}" > %{specpartsdir}/rpm-debuginfo.specpart)}" : "" ]\
-%[ 0%{?_enable_sbom_packages} > 0 ? "%{?buildsubdir:%{expand:%%global __sbom_package 1}%(echo "%{_sbom_template}" > %{specpartsdir}/rpm-sbom.specpart)}" : "" ]\
+%[ 0%{?_enable_sbom_packages} > 0 ? "%{expand:%%global __sbom_package 1}%(echo "%{_sbom_template}" > %{specpartsdir}/rpm-sbom.specpart)" : "" ]\
 %{nil}
 
 %_cross_sbom_build_dir %{_builddir}


### PR DESCRIPTION
<!--
Tips:
- Please read the CONTRIBUTING document to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->

**Description of changes:**
Rust packages i n the core and kernel kit redefine the generate sbom macro purely so that that they can change the build_dir used by the macro. By exposing the directory as a different, redefinable macro we simplify what these sorts of packages need to change.

Removing the `buildsubdir` broadens the scope of packages that will generate an SBOM package. While many of these will be blank SBOMs, some will not so, we'll opt for the widest possible net.


**Testing done:**
Built an SDK and then a core kit


**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
