### PR TITLE
enable minimal debuginfo

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -495,7 +495,7 @@ FROM sdk-libc AS sdk-go-prep
 # Set up the environment for building.
 ENV GOOS="linux"
 ENV CGO_ENABLED=1
-ENV CFLAGS="-O2 -g -pipe -Wformat -Werror=format-security -Wp,-D_FORTIFY_SOURCE=2 -Wp,-D_GLIBCXX_ASSERTIONS -fexceptions -fstack-clash-protection -fno-omit-frame-pointer"
+ENV CFLAGS="-O2 -g1 -pipe -Wformat -Werror=format-security -Wp,-D_FORTIFY_SOURCE=2 -Wp,-D_GLIBCXX_ASSERTIONS -fexceptions -fstack-clash-protection -fno-omit-frame-pointer"
 ENV CXXFLAGS="${CFLAGS}"
 ENV LDFLAGS="-Wl,-z,relro -Wl,-z,now"
 ENV CGO_CFLAGS="${CFLAGS}"

--- a/helpers/musl/build-musl.sh
+++ b/helpers/musl/build-musl.sh
@@ -14,7 +14,7 @@ ARCH="${ARCH:?}"
 
 TARGET="${ARCH}-bottlerocket-linux-musl"
 SYSROOT="/${TARGET}/sys-root"
-CFLAGS="-O2 -g -pipe -Wall -Werror=format-security -Wp,-D_FORTIFY_SOURCE=2 -Wp,-D_GLIBCXX_ASSERTIONS -fexceptions -fstack-clash-protection -fno-omit-frame-pointer -mno-omit-leaf-frame-pointer"
+CFLAGS="-O2 -g1 -pipe -Wall -Werror=format-security -Wp,-D_FORTIFY_SOURCE=2 -Wp,-D_GLIBCXX_ASSERTIONS -fexceptions -fstack-clash-protection -fno-omit-frame-pointer -mno-omit-leaf-frame-pointer"
 LDFLAGS="-Wl,-z,relro -Wl,-z,now"
 
 case "${ARCH}" in

--- a/macros/rust
+++ b/macros/rust
@@ -10,7 +10,7 @@
 
 # Enable some optimization, debuginfo, and link hardening.
 %__global_rustflags_base %{shrink: \
-  -Copt-level=3 -Cdebuginfo=2 -Cforce-frame-pointers=yes \
+  -Copt-level=3 -Cdebuginfo=line-tables-only -Cforce-frame-pointers=yes \
   %{_cross_arch_rust_flags} \
   -Clink-arg=-Wl,-z,relro,-z,now \
   -Clink-arg=-Wl,-z,pack-relative-relocs \

--- a/macros/shared
+++ b/macros/shared
@@ -6,7 +6,7 @@
 %dist %{nil}
 
 %_cross_cflags %{shrink: \
-  -O2 -g -pipe -Wall \
+  -O2 -g1 -pipe -Wall \
   -Werror=trampolines -Wbidi-chars=any \
   -Werror=format-security -Werror=strict-aliasing \
   -Wp,-U_FORTIFY_SOURCE -Wp,-D_FORTIFY_SOURCE=2 \
@@ -356,18 +356,12 @@ This package provides SBOM files for %{name}.\
 %__requires_exclude ^.*$
 %__provides_exclude ^.*$
 
-# Do not generate build ID links in main packages.
-%_build_id_links alldebug
-
 # Do not run ldconfig after build.
 %__brp_ldconfig %{nil}
 
 # Disable mangling since we do not have interpreters, and this causes build
 # failures when rewriting "shebangs" in crate files.
 %__brp_mangle_shebangs /bin/true
-
-# Do not compress debuginfo.
-%_find_debuginfo_dwz_opts %{nil}
 
 # Compress RPM payloads with zstd level 1 in single-threaded mode.
 %_source_payload w1.zstdio
@@ -417,7 +411,9 @@ This package provides SBOM files for %{name}.\
   sed -i 's|^hardcode_libdir_flag_spec=.*|hardcode_libdir_flag_spec=""|g' libtool \
   sed -i 's|^runpath_var=LD_RUN_PATH|runpath_var=DIE_RPATH_DIE|g' libtool
 
-# By default, find-debuginfo comes from /usr/bin, and adds the tools there to
-# the path ahead of any other directories. To force it to use the target-specific
-# binutils programs, point to the symlink in the debuginfo override path instead.
-%__find_debuginfo /usr/%{_cross_target}/debuginfo/bin/find-debuginfo
+# Disable all debug packages.
+%__debug_install_post %{nil}
+%_debuginfo_template %{nil}
+%_debugsource_template %{nil}
+%_enable_debug_packages %{nil}
+%debug_package %{nil}


### PR DESCRIPTION
**Issue number:**
Fixes #219

**Description of changes:**
Ensure that minimal debuginfo covering functions and line numbers is included in all binaries. This makes it straightforward to use tools like `perf` to profile a running system and graph function calls.

Disable the various macros that extract and compress debuginfo, since that causes the minimal debuginfo to be extracted and packaged inside separate RPMs.

For downstream variants using EROFS to compress the root filesystem, the overall cost is around 5% increased disk usage, or around 15 MiB for a 300 MiB install. That's about the same as adding another Go program to the default install.


**Testing done:**
`aws-k8s-1.35` root filesystem utilization:
| architecture | before | after |
| --- | --- | --- |
| aarch64 | 271M | 285M |
| x86_64 | 310M | 326M |

These numbers also include space savings from #333.

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
