### PR TITLE
Revert "Merge pull request #328 from rpkelly/sbom-build-dir"

### DIFF
--- a/macros/shared
+++ b/macros/shared
@@ -330,11 +330,9 @@ This package provides SBOM files for %{name}.\
 %[ 0%{?_enable_sbom_packages} > 0 ? "%{expand:%%global __sbom_package 1}%(echo "%{_sbom_template}" > %{specpartsdir}/rpm-sbom.specpart)" : "" ]\
 %{nil}
 
-%_cross_sbom_build_dir %{_builddir}
-
 %cross_generate_sbom \
   mkdir -p %{_builddir}/sbom-temp \
-  sbomtool generate --name %{_uncross_name} --out-dir %{_builddir}/sbom-temp --build-dir %{_cross_sbom_build_dir} --spdx --cyclonedx
+  sbomtool generate --name %{_uncross_name} --out-dir %{_builddir}/sbom-temp --build-dir %{_builddir} --spdx --cyclonedx
 
 %cross_install_sbom \
   install -d %{buildroot}%{_cross_sbom_package_dir} \

--- a/macros/shared
+++ b/macros/shared
@@ -299,6 +299,7 @@ CROSS_CMAKE_TOOLCHAIN_EOF\
 %_sbom_template \
 %ifnarch noarch\
 %global __sbom_package 1\
+%{?buildsubdir:%%global __sbom_package 1}\
 %package sbom\
 Summary: SBOM (Software Bill of Materials) for %{name}\
 AutoReqProv: 0\
@@ -315,6 +316,7 @@ This package provides SBOM files for %{name}.\
 %sbom_package \
 %ifnarch noarch\
 %global __sbom_package 1\
+%{?buildsubdir:%%global __sbom_package 1}\
 %_sbom_template\
 %endif\
 %{nil}
@@ -327,7 +329,7 @@ This package provides SBOM files for %{name}.\
 %__spec_install_template\
 %{__spec_install_pre}\
 %[ 0%{?_enable_debug_packages} > 0 ? "%{?buildsubdir:%(echo "%{debug_package}" > %{specpartsdir}/rpm-debuginfo.specpart)}" : "" ]\
-%[ 0%{?_enable_sbom_packages} > 0 ? "%{expand:%%global __sbom_package 1}%(echo "%{_sbom_template}" > %{specpartsdir}/rpm-sbom.specpart)" : "" ]\
+%[ 0%{?_enable_sbom_packages} > 0 ? "%{?buildsubdir:%{expand:%%global __sbom_package 1}%(echo "%{_sbom_template}" > %{specpartsdir}/rpm-sbom.specpart)}" : "" ]\
 %{nil}
 
 %cross_generate_sbom \


### PR DESCRIPTION
This commit causes a conflict with the metatdata package generated by twoliter. Since this commit attempts to allow more types of packages to generate SBOMs, the metadata packages now attempts to generate an sbom. Unfortunately, it already has a subpackage called sbom.

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
