### PR TITLE
build: update base image to Fedora 43

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM public.ecr.aws/docker/library/fedora:41 AS base
+FROM public.ecr.aws/docker/library/fedora:43 AS base
 
 # Everything we need to build our SDK and packages.
 RUN \

--- a/macros/shared
+++ b/macros/shared
@@ -5,6 +5,9 @@
 %_cross_target %{_cross_triple}-%{_cross_libc}
 %dist %{nil}
 
+# Fedora 42 unified /usr/bin and /usr/sbin making the latter symlink of the former
+%_sbindir /usr/sbin
+
 %_cross_cflags %{shrink: \
   -O2 -g1 -pipe -Wall \
   -Werror=trampolines -Wbidi-chars=any \


### PR DESCRIPTION
**Description of changes:**
1. Update container image from Fedora - 43

Not contained in this update is an update to Go package. The update is necessary in aarch64 to fix an unit test. It will be part of a separate PR.

**Testing done:**
Container image update:
1. Compared the checksec result - it matched for all binaries
3. Compared the sizes - it matched for all binaries except `mount` and `umount`. This is okay because `mount` and `umount` retain the debug sections in their binaries post rpmbuild. As mentioned here: https://fedoraproject.org/wiki/Changes/StaticLibraryPreserveDebuginfo, Fedora 43 allows some additional sections of debug info compared to Fedora 41 which caused the 840 bytes size difference.
4. Built bottlerocket-core-kit (no changes), built bottlerocket-kernel-kit (requires update to package cert verification step for neuron package), built bottlerocket - instance boots, joins cluster, ran go-nodejs container in non-nvidia instance, ran nvidia-smoke-test on nvidia-instance (for both arches)


**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
