### PR TITLE
add libseccomp-devel to the SDK

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -866,6 +866,7 @@ RUN \
     less \
     libbpf-devel \
     libcap-devel \
+    libseccomp-devel \
     libkcapi-hmaccalc \
     lz4 \
     mtools \


### PR DESCRIPTION



**Description of changes:**
add libseccomp-devel to the SDK


**Testing done:**
* Built SDK on x86 
* Built SDK on aarch64 

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
