### PR TITLE
Install systemd-ukify

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -36,6 +36,7 @@ RUN \
     perl-IPC-Cmd \
     perl-open \
     python \
+    systemd-ukify \
     rsync \
     wget \
     which \


### PR DESCRIPTION
**Description of changes:**

This package is required for the upcoming UKI support in Bottlerocket. It provides ukify, which is the tool provided by the systemd maintainers to generate UKIs.


**Testing done:**

- SDK builds
- I can run `ukify` from within the SDK container:

```bash
docker run --rm --entrypoint bash -it bottlerocket-sdk:v0.77.0-0efac6b2-amd64
bash-5.3$ ukify --version
ukify 258 (258.10-1.fc43)
bash-5.3$
```

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
