### PR TITLE
govc: update to v0.55.1

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -689,9 +689,9 @@ RUN \
   mkdir -p /usr/libexec/tools /usr/share/licenses/govmomi && \
   chown -R builder:builder /usr/libexec/tools /usr/share/licenses/govmomi
 
-ENV GOVMOMIVER="0.46.3"
-ENV GOVMOMISHORTCOMMIT="e5dcb5f"
-ENV GOVMOMIDATE="2024-12-12T20:11:39Z"
+ENV GOVMOMIVER="0.55.1"
+ENV GOVMOMISHORTCOMMIT="1e372f1"
+ENV GOVMOMIDATE="2026-07-03T14:30:07Z"
 
 USER builder
 WORKDIR /home/builder/go/src/github.com/vmware/govmomi
@@ -704,16 +704,16 @@ RUN \
 COPY --chown=0:0 --from=sdk-rust-tools /usr/libexec/tools/ /usr/libexec/tools/
 RUN \
   cp -p LICENSE.txt /usr/share/licenses/govmomi && \
-  go mod vendor && \
+  go -C govc mod vendor && \
   /usr/libexec/tools/bottlerocket-license-scan \
     --spdx-data /usr/libexec/tools/spdx-data \
     --out-dir /usr/share/licenses/govmomi/vendor \
-    go-vendor ./vendor
+    go-vendor ./govc/vendor
 
 RUN \
   export CGO_ENABLED=0 ; \
-  export BUILD_VERSION_PKG="github.com/vmware/govmomi/govc/flags" ; \
-  go build -mod=vendor -o /usr/libexec/tools/govc -ldflags " \
+  export BUILD_VERSION_PKG="github.com/vmware/govmomi/cli/flags" ; \
+  go -C govc build -mod=vendor -o /usr/libexec/tools/govc -ldflags " \
     -s -w \
     -X ${BUILD_VERSION_PKG}.BuildVersion=${GOVMOMIVER} \
     -X ${BUILD_VERSION_PKG}.BuildCommit=${GOVMOMISHORTCOMMIT} \

--- a/hashes/govmomi
+++ b/hashes/govmomi
@@ -1,2 +1,2 @@
-# https://github.com/vmware/govmomi/archive/v0.46.3/govmomi-0.46.3.tar.gz
-SHA512 (govmomi-0.46.3.tar.gz) = 149830359e966a3090348fe80fecc58dfd19394dc5df0cc97e4ee245866738802437c6a099b95e9ff1595696644e6dacba07151ce17b73bd384f3cd918549410
+# https://github.com/vmware/govmomi/archive/v0.55.1/govmomi-0.55.1.tar.gz
+SHA512 (govmomi-0.55.1.tar.gz) = 22ad4edaf62241015cb0c968767cb591e6439bc876d2e9d079364c0c1c67fff246a9157e0c1bf077772f87ac7eaf7a3832f12130ca6fafc90fe7e3bb0dc6fe57


### PR DESCRIPTION
**Description of changes:**

Updates to a newer version of `govc`. Build commands were adjusted to accommodate `govc` commands moving into the `govmomi/cli` pkg from **0.47.0** onward.

**Testing done:**

```bash
bash-5.3$ govc version -l
Build Version: 0.55.1
Build Commit: 1e372f1
Build Date: 2026-07-03T14:30:07Z
```

Also ran some basic commands while authenticated to vSphere.

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
